### PR TITLE
compare BigDecimal data values using compareTo instead of equals

### DIFF
--- a/src/main/java/de/learnlib/ralib/tools/theories/DoubleDataValue.java
+++ b/src/main/java/de/learnlib/ralib/tools/theories/DoubleDataValue.java
@@ -1,0 +1,21 @@
+package de.learnlib.ralib.tools.theories;
+
+import java.math.BigDecimal;
+
+import de.learnlib.ralib.data.DataType;
+import de.learnlib.ralib.data.DataValue;
+
+public class DoubleDataValue extends DataValue<BigDecimal> {
+
+	DoubleDataValue(DataType type, BigDecimal id) {
+		super(type, id);
+	}
+
+	@Override
+	public boolean equals(Object other) {
+		if (other instanceof DoubleDataValue && id.compareTo(((DoubleDataValue) other).getId()) == 0)
+			return true;
+		return super.equals(other);
+	}
+
+}

--- a/src/main/java/de/learnlib/ralib/tools/theories/DoubleInequalityTheory.java
+++ b/src/main/java/de/learnlib/ralib/tools/theories/DoubleInequalityTheory.java
@@ -99,7 +99,7 @@ public class DoubleInequalityTheory extends InequalityTheoryWithEq<BigDecimal> i
             // pick up the register
             SymbolicDataValue si = ((SDTIfGuard) g).getRegister();
             // get the register value from the valuation
-            DataValue<BigDecimal> sdi = new DataValue(type, (BigDecimal) val.getValue(toVariable(si)));
+            DataValue<BigDecimal> sdi = new DoubleDataValue(type, (BigDecimal) val.getValue(toVariable(si)));
             // add the register value as a constant
             gov.nasa.jpf.constraints.expressions.Constant wm = new gov.nasa.jpf.constraints.expressions.Constant(BuiltinTypes.DECIMAL, (sdi.getId()));
             // add the constant equivalence expression to the list
@@ -109,7 +109,7 @@ public class DoubleInequalityTheory extends InequalityTheoryWithEq<BigDecimal> i
             IntervalGuard iGuard = (IntervalGuard) g;
             if (!iGuard.isBiggerGuard()) {
                 SymbolicDataValue r = iGuard.getRightReg();
-                DataValue<BigDecimal> ri = new DataValue(type, (BigDecimal) val.getValue(toVariable(r)));
+                DataValue<BigDecimal> ri = new DoubleDataValue(type, (BigDecimal) val.getValue(toVariable(r)));
                 gov.nasa.jpf.constraints.expressions.Constant wm = new gov.nasa.jpf.constraints.expressions.Constant(BuiltinTypes.DECIMAL, (ri.getId()));
                 // add the constant equivalence expression to the list
                 eList.add(new NumericBooleanExpression(wm, NumericComparator.EQ, toVariable(r)));
@@ -117,7 +117,7 @@ public class DoubleInequalityTheory extends InequalityTheoryWithEq<BigDecimal> i
             }
             if (!iGuard.isSmallerGuard()) {
                 SymbolicDataValue l = iGuard.getLeftReg();
-                DataValue<BigDecimal> li = new DataValue(type, (BigDecimal) val.getValue(toVariable(l)));
+                DataValue<BigDecimal> li = new DoubleDataValue(type, (BigDecimal) val.getValue(toVariable(l)));
                 gov.nasa.jpf.constraints.expressions.Constant wm = new gov.nasa.jpf.constraints.expressions.Constant(BuiltinTypes.DECIMAL, (li.getId()));
                 // add the constant equivalence expression to the list
                 eList.add(new NumericBooleanExpression(wm, NumericComparator.EQ, toVariable(l)));
@@ -128,7 +128,7 @@ public class DoubleInequalityTheory extends InequalityTheoryWithEq<BigDecimal> i
     }
 
     @Override
-    public DataValue<BigDecimal> instantiate(SDTGuard g, Valuation val, Constants c, Collection<DataValue<BigDecimal>> alreadyUsedValues) {
+    public DoubleDataValue instantiate(SDTGuard g, Valuation val, Constants c, Collection<DataValue<BigDecimal>> alreadyUsedValues) {
         //System.out.println("INSTANTIATING: " + g.toString());
         SymbolicDataValue.SuffixValue sp = g.getParameter();
         Valuation newVal = new Valuation();
@@ -160,7 +160,7 @@ public class DoubleInequalityTheory extends InequalityTheoryWithEq<BigDecimal> i
             }
 
             if (newVal.containsValueFor(toVariable(sp))) {
-                DataValue<BigDecimal> spDouble = new DataValue(type, newVal.getValue(toVariable(sp)));
+                DoubleDataValue spDouble = new DoubleDataValue(type, (BigDecimal)newVal.getValue(toVariable(sp)));
                 gov.nasa.jpf.constraints.expressions.Constant spw = new gov.nasa.jpf.constraints.expressions.Constant(BuiltinTypes.DECIMAL, (spDouble.getId()));
                 Expression<Boolean> spExpr = new NumericBooleanExpression(spw, NumericComparator.EQ, toVariable(sp));
                 eList.add(spExpr);
@@ -177,7 +177,7 @@ public class DoubleInequalityTheory extends InequalityTheoryWithEq<BigDecimal> i
         if (res == Result.SAT) {
 //                    System.out.println("SAT!!");
 //                    System.out.println(newVal.getValue(sp.toVariable()) + "   " + newVal.getValue(sp.toVariable()).getClass());
-            DataValue<BigDecimal> d = new DataValue(type, (newVal.getValue(toVariable(sp))));
+            DoubleDataValue d = new DoubleDataValue(type, (BigDecimal)(newVal.getValue(toVariable(sp))));
             //System.out.println("return d: " + d.toString());
             return d;//new DataValue<Double>(doubleType, d);
         } else {
@@ -187,17 +187,17 @@ public class DoubleInequalityTheory extends InequalityTheoryWithEq<BigDecimal> i
     }
 
     @Override
-    public DataValue<BigDecimal> getFreshValue(List<DataValue<BigDecimal>> vals) {
+    public DoubleDataValue getFreshValue(List<DataValue<BigDecimal>> vals) {
         if (vals.isEmpty()) {
-            return new DataValue(type, BigDecimal.ONE);
+            return new DoubleDataValue(type, BigDecimal.ONE);
         }
         List<DataValue<BigDecimal>> potential = getPotential(vals);
         if (potential.isEmpty()) {
-            return new DataValue(type, BigDecimal.ONE);
+            return new DoubleDataValue(type, BigDecimal.ONE);
         }
         //log.log(Level.FINEST, "smallest index of " + newDv.toString() + " in " + ifValues.toString() + " is " + smallest);
         DataValue<BigDecimal> biggestDv = Collections.max(potential, new Cpr());
-        return new DataValue(type, biggestDv.getId().add(BigDecimal.ONE));
+        return new DoubleDataValue(type, biggestDv.getId().add(BigDecimal.ONE));
     }
 
     @Override
@@ -223,20 +223,20 @@ public class DoubleInequalityTheory extends InequalityTheoryWithEq<BigDecimal> i
         Set<DataValue<BigDecimal>> nextValues = new LinkedHashSet<>();
         nextValues.addAll(vals);
         if (vals.isEmpty()) {
-            nextValues.add(new DataValue(type, BigDecimal.ONE));
+            nextValues.add(new DoubleDataValue(type, BigDecimal.ONE));
         } else {
             Collections.sort(vals, new Cpr());
             if (vals.size() > 1) {
                 for (int i = 0; i < (vals.size() - 1); i++) {
                     BigDecimal d1 = vals.get(i).getId();
                     BigDecimal d2 = vals.get(i + 1).getId();
-                    nextValues.add(new DataValue(type,
+                    nextValues.add(new DoubleDataValue(type,
                             d2.subtract(d1).divide(BigDecimal.valueOf(2.0)).add(d1)));
                             //(d1 + ((d2 - d1) / 2))));
                 }
             }
-            nextValues.add(new DataValue(type, (Collections.min(vals, new Cpr()).getId().subtract(BigDecimal.ONE))));
-            nextValues.add(new DataValue(type, (Collections.max(vals, new Cpr()).getId().add(BigDecimal.ONE))));
+            nextValues.add(new DoubleDataValue(type, (Collections.min(vals, new Cpr()).getId().subtract(BigDecimal.ONE))));
+            nextValues.add(new DoubleDataValue(type, (Collections.max(vals, new Cpr()).getId().add(BigDecimal.ONE))));
         }
         return nextValues;
     }

--- a/src/test/java/de/learnlib/ralib/learning/rattt/LearnPQIOTest.java
+++ b/src/test/java/de/learnlib/ralib/learning/rattt/LearnPQIOTest.java
@@ -69,6 +69,39 @@ public class LearnPQIOTest extends RaLibTestSuite {
         final Constants consts = new Constants();
 
         PriorityQueueSUL sul = new PriorityQueueSUL();
+
+        RegisterAutomaton hyp = learnPQ(seed, teachers, consts, sul);
+        RegisterAutomatonImporter imp = TestUtil.getLoader(
+                "/de/learnlib/ralib/automata/xml/pq3.xml");
+
+        IOEquivalenceTest checker = new IOEquivalenceTest(
+                imp.getRegisterAutomaton(), teachers, consts, true,
+                sul.getActionSymbols()
+        );
+
+        Assert.assertNull(checker.findCounterExample(hyp, null));
+
+    }
+
+    @Test
+    public void testPQIODoublePrecisionError() {
+        final Map<DataType, Theory> teachers = new LinkedHashMap<>();
+        teachers.put(PriorityQueueSUL.DOUBLE_TYPE,
+                new DoubleInequalityTheory(PriorityQueueSUL.DOUBLE_TYPE));
+
+        final Constants consts = new Constants();
+
+        PriorityQueueSUL sul = new PriorityQueueSUL();
+        learnPQ(6, teachers, consts, sul);
+
+        // test is passed if we reach this point without triggering an exception
+        Assert.assertTrue(true);
+    }
+
+    private Hypothesis learnPQ(long seed, Map<DataType, Theory> teachers, Constants consts, PriorityQueueSUL sul) {
+        logger.log(Level.FINE, "SEED={0}", seed);
+        final Random random = new Random(seed);
+
         JConstraintsConstraintSolver jsolv = TestUtil.getZ3Solver();
         IOOracle ioOracle = new SULOracle(sul, PriorityQueueSUL.ERROR);
 
@@ -120,16 +153,7 @@ public class LearnPQIOTest extends RaLibTestSuite {
             rastar.addCounterexample(ce);
         }
 
-        RegisterAutomaton hyp = rastar.getHypothesis();
-        RegisterAutomatonImporter imp = TestUtil.getLoader(
-                "/de/learnlib/ralib/automata/xml/pq3.xml");
-
-        IOEquivalenceTest checker = new IOEquivalenceTest(
-                imp.getRegisterAutomaton(), teachers, consts, true,
-                sul.getActionSymbols()
-        );
-
-        Assert.assertNull(checker.findCounterExample(hyp, null));
+        return rastar.getHypothesis();
 
     }
 }


### PR DESCRIPTION
Implements a wrapper around BigDecimal data values which compares the BigDecimal values using compareTo rather than equals, so that values can be compared which are equal except for their precision.