### PR TITLE
Fix calls to deprecated APIs

### DIFF
--- a/src/main/java/de/learnlib/ralib/learning/SymbolicSuffix.java
+++ b/src/main/java/de/learnlib/ralib/learning/SymbolicSuffix.java
@@ -67,9 +67,9 @@ public class SymbolicSuffix {
     	actions = Word.fromWords(s.actions);
 
     	for (SuffixValue sv : s.freeValues)
-    		freeValues.add(sv.copy());
+            freeValues.add(sv.copy());
     	for (Map.Entry<Integer, SuffixValue> dv : s.dataValues.entrySet())
-    		dataValues.put(new Integer(dv.getKey()), dv.getValue().copy());
+            dataValues.put(Integer.valueOf(dv.getKey()), dv.getValue().copy());
     }
 
     /**

--- a/src/main/java/de/learnlib/ralib/tools/AbstractToolWithRandomWalk.java
+++ b/src/main/java/de/learnlib/ralib/tools/AbstractToolWithRandomWalk.java
@@ -16,6 +16,7 @@
  */
 package de.learnlib.ralib.tools;
 
+import java.lang.reflect.InvocationTargetException;
 import java.util.ArrayList;
 import java.util.EnumSet;
 import java.util.HashMap;
@@ -244,7 +245,7 @@ public abstract class AbstractToolWithRandomWalk implements RaLibTool {
             String[] parts = config.trim().split(":");
             Class<?> cl = Class.forName(parts[1].trim());
 
-            TypedTheory th = (TypedTheory) cl.newInstance();
+            TypedTheory th = (TypedTheory) cl.getDeclaredConstructor().newInstance();
             String t = parts[0].trim();
             // Do this later !!!
             // th.setType(t);
@@ -252,7 +253,7 @@ public abstract class AbstractToolWithRandomWalk implements RaLibTool {
 
             return Pair.of(t, th);
 
-        } catch (ClassNotFoundException | InstantiationException | IllegalAccessException ex) {
+        } catch (ClassNotFoundException | InstantiationException | IllegalAccessException | NoSuchMethodException | InvocationTargetException ex) {
             throw new ConfigurationException(ex.getMessage());
         }
     }

--- a/src/main/java/de/learnlib/ralib/tools/ConsoleClient.java
+++ b/src/main/java/de/learnlib/ralib/tools/ConsoleClient.java
@@ -18,6 +18,7 @@ package de.learnlib.ralib.tools;
 
 import java.io.File;
 import java.io.IOException;
+import java.lang.reflect.InvocationTargetException;
 import java.util.Arrays;
 import java.util.LinkedHashMap;
 import java.util.Map;
@@ -110,14 +111,14 @@ public class ConsoleClient {
         }
     }
 
-    private void parseTool() throws InstantiationException, IllegalAccessException {
+    private void parseTool() throws InstantiationException, IllegalAccessException, InvocationTargetException, NoSuchMethodException {
         if (args.length < 1) {
             return;
         }
 
         toolname = args[0];
         Class<? extends RaLibTool> toolClass = tools.get(toolname);
-        this.tool = toolClass.newInstance();
+        this.tool = toolClass.getDeclaredConstructor().newInstance();
     }
 
     private void parseConfig() throws IOException {

--- a/src/main/java/de/learnlib/ralib/tools/classanalyzer/ClasssAnalyzerDataWordSUL.java
+++ b/src/main/java/de/learnlib/ralib/tools/classanalyzer/ClasssAnalyzerDataWordSUL.java
@@ -60,8 +60,8 @@ public class ClasssAnalyzerDataWordSUL extends DataWordSUL {
         buckets.clear();
         depth = 0;
         try {
-            sul = sulClass.newInstance();
-        } catch (InstantiationException | IllegalAccessException ex) {
+            sul = sulClass.getDeclaredConstructor().newInstance();
+        } catch (InstantiationException | IllegalAccessException | InvocationTargetException | NoSuchMethodException ex) {
             throw new RuntimeException(ex);
         }
     }


### PR DESCRIPTION
The `Class.newInstance()` calls are deprecated (from Java 9 onward).
Change them to use the `Class.getDeclaredConstructor().newInstance()` form and handle/document the additional exceptions that can occur.
While at it, also modernize a way to create an `Integer` instance.