### PR TITLE
Use entrySet() instead of keySet() for iteration

### DIFF
--- a/src/main/java/de/learnlib/ralib/data/Mapping.java
+++ b/src/main/java/de/learnlib/ralib/data/Mapping.java
@@ -95,12 +95,12 @@ public class Mapping<K, V extends DataValue<?>> extends LinkedHashMap<K, V>
 
     public Set<K> getAllKeys(V value) {
         Set<K> retKeySet = new LinkedHashSet();
-        for (K key : this.keySet()) {
+        for (Map.Entry<K,V> entry : this.entrySet()) {
             //log.trace("key = " + K);
-            //log.trace("value = " + this.get(key).toString());
-            if (this.get(key).equals(value)){
-                //log.trace(this.get(key).toString() + " equals " + value.toString());
-                retKeySet.add(key);
+            //log.trace("value = " + entry.getKey().toString());
+            if (entry.getValue().equals(value)){
+                //log.trace(entry.getKey().toString() + " equals " + value.toString());
+                retKeySet.add(entry.getKey());
             }
         }
         return retKeySet;

--- a/src/main/java/de/learnlib/ralib/data/PIV.java
+++ b/src/main/java/de/learnlib/ralib/data/PIV.java
@@ -76,12 +76,12 @@ public class PIV extends VarMapping<Parameter, Register> {
     //FIXME: this method is bogus. There may be more than one value.
     public Parameter getOneKey(Register value) {
         Parameter retKey = null;
-        for (Parameter key : this.keySet()) {
-//            System.out.println("key = " + key.toString());
-//            System.out.println("value = " + this.get(key).toString());
-            if (this.get(key).getId().equals(value.getId())){
-//                System.out.println(this.get(key).toString() + " equals " + value.toString());
-                retKey = key;
+        for (Map.Entry<Parameter,Register> entry : this.entrySet()) {
+//            System.out.println("key = " + entry.getKey().toString());
+//            System.out.println("value = " + entry.getValue().toString());
+            if (entry.getValue().getId().equals(value.getId())){
+//                System.out.println(entry.getValue().toString() + " equals " + value.toString());
+                retKey = entry.getKey();
                 break;
             }
         }

--- a/src/main/java/de/learnlib/ralib/data/util/PIVRemappingIterator.java
+++ b/src/main/java/de/learnlib/ralib/data/util/PIVRemappingIterator.java
@@ -57,9 +57,9 @@ public class PIVRemappingIterator implements Iterable<VarMapping>, Iterator<VarM
         byParams = new Parameter[by_ta.size()][];
 
         int idx = 0;
-        for (DataType t : rep_ta.keySet()) {
-            replaceParams[idx] = rep_ta.get(t);
-            byParams[idx] = by_ta.get(t);
+        for (Map.Entry <DataType, Parameter[]> entry : rep_ta.entrySet()) {
+            replaceParams[idx] = entry.getValue();
+            byParams[idx] = by_ta.get(entry.getKey());
             iterators[idx] = new PermutationIterator(replaceParams[idx].length);
             iterators[idx].next();
             idx++;

--- a/src/main/java/de/learnlib/ralib/dt/PathResult.java
+++ b/src/main/java/de/learnlib/ralib/dt/PathResult.java
@@ -66,9 +66,9 @@ public class PathResult {
             return false;
         }
 
-        for (SymbolicSuffix s : this.results.keySet()) {
-            TreeQueryResult c1 = this.results.get(s);
-            TreeQueryResult c2 = other.results.get(s);
+        for (Map.Entry<SymbolicSuffix, TreeQueryResult> e : this.results.entrySet()) {
+            TreeQueryResult c1 = e.getValue();
+            TreeQueryResult c2 = other.results.get(e.getKey());
 
             if (ioMode) {
                 if (c1 == null && c2 == null) {
@@ -102,9 +102,9 @@ public class PathResult {
             return false;
         }
 
-        for (SymbolicSuffix s : this.results.keySet()) {
-            TreeQueryResult c1 = this.results.get(s);
-            TreeQueryResult c2 = other.results.get(s);
+        for (Map.Entry<SymbolicSuffix, TreeQueryResult> e : this.results.entrySet()) {
+            TreeQueryResult c1 = e.getValue();
+            TreeQueryResult c2 = other.results.get(e.getKey());
 
             if (ioMode) {
                 if (c1 == null && c2 == null) {

--- a/src/main/java/de/learnlib/ralib/equivalence/IOEquivalenceTest.java
+++ b/src/main/java/de/learnlib/ralib/equivalence/IOEquivalenceTest.java
@@ -120,7 +120,7 @@ public class IOEquivalenceTest implements IOEquivalenceOracle
 
     private boolean compatible(Tuple t1, Tuple t2)
     {
-        // compare lcoations ...
+        // compare locations ...
         if (!t1.equals(t2))
             return false;
 
@@ -139,10 +139,10 @@ public class IOEquivalenceTest implements IOEquivalenceOracle
     private boolean compareRegister(
             VarValuation r1, VarValuation r2, Map<Object,Object> vMap) {
 
-        for (Register key : r1.keySet())
+        for (Map.Entry<Register,DataValue<?>> entry : r1.entrySet())
         {
-            DataValue v1 = r1.get(key);
-            DataValue v2 = r2.get(key);
+            DataValue v1 = entry.getValue();
+            DataValue v2 = r2.get(entry.getKey());
 
             boolean n1 = (v1 == null);
             boolean n2 = (v2 == null);

--- a/src/main/java/de/learnlib/ralib/equivalence/RAEquivalenceTest.java
+++ b/src/main/java/de/learnlib/ralib/equivalence/RAEquivalenceTest.java
@@ -121,7 +121,7 @@ public class RAEquivalenceTest implements IOEquivalenceOracle
 
     private boolean compatible(Tuple t1, Tuple t2)
     {
-        // compare lcoations ...
+        // compare locations ...
         if (!t1.equals(t2))
             return false;
 
@@ -140,10 +140,10 @@ public class RAEquivalenceTest implements IOEquivalenceOracle
     private boolean compareRegister(
             VarValuation r1, VarValuation r2, Map<Object,Object> vMap) {
 
-        for (Register key : r1.keySet())
+        for (Map.Entry<Register,DataValue<?>> entry : r1.entrySet())
         {
-            DataValue v1 = r1.get(key);
-            DataValue v2 = r2.get(key);
+            DataValue v1 = entry.getValue();
+            DataValue v2 = r2.get(entry.getKey());
 
             boolean n1 = (v1 == null);
             boolean n2 = (v2 == null);
@@ -166,7 +166,7 @@ public class RAEquivalenceTest implements IOEquivalenceOracle
                         return false;
                 }
             }
-            vMap.put( v1.getId(), v2.getId());
+            vMap.put(v1.getId(), v2.getId());
         }
 
         return true;

--- a/src/main/java/de/learnlib/ralib/learning/SymbolicSuffix.java
+++ b/src/main/java/de/learnlib/ralib/learning/SymbolicSuffix.java
@@ -70,7 +70,7 @@ public class SymbolicSuffix {
     	for (SuffixValue sv : s.freeValues)
     		freeValues.add(sv.copy());
     	for (Map.Entry<Integer, SuffixValue> dv : s.dataValues.entrySet())
-    		dataValues.put(new Integer(dv.getKey()), dv.getValue().copy());
+             dataValues.put(dv.getKey(), dv.getValue().copy());
     }
 
     /**

--- a/src/main/java/de/learnlib/ralib/learning/ralambda/RaLambda.java
+++ b/src/main/java/de/learnlib/ralib/learning/ralambda/RaLambda.java
@@ -325,11 +325,12 @@ public class RaLambda implements RaLearningAlgorithm {
 
     private boolean checkGuardConsistency() {
     	Map<Word<PSymbolInstance>, Boolean> toReuse = new LinkedHashMap<Word<PSymbolInstance>, Boolean>();
-    	for (Word<PSymbolInstance> word : guardPrefixes.keySet()) {
-    		Word<PSymbolInstance> src_id = word.prefix(word.size() - 1);
-    		DTLeaf src_c = dt.getLeaf(src_id);
-    		DTLeaf dest_c = dt.getLeaf(word);
-            Branching hypBranching = null;
+	for (Map.Entry<Word<PSymbolInstance>, Boolean> entry : guardPrefixes.entrySet()) {
+	    Word<PSymbolInstance> word = entry.getKey();
+	    Word<PSymbolInstance> src_id = word.prefix(word.size() - 1);
+	    DTLeaf src_c = dt.getLeaf(src_id);
+	    DTLeaf dest_c = dt.getLeaf(word);
+	    Branching hypBranching = null;
             if (src_c.getAccessSequence().equals(src_id)) {
                 hypBranching = src_c.getBranching(word.lastSymbol().getBaseSymbol());
             } else {
@@ -349,7 +350,7 @@ public class RaLambda implements RaLearningAlgorithm {
             	suffix = distinguishingSuffix(branch, branchLeaf, word, dest_c);
             }
             else {
-            	if (!guardPrefixes.get(word)) {
+			if (!entry.getValue()) {
 		            MappedPrefix mp = dest_c.getPrefix(word);
 		            Map<SymbolicSuffix, TreeQueryResult> branchTQRs = branchLeaf.getPrefix(branch).getTQRs();
 		            for (Map.Entry<SymbolicSuffix, TreeQueryResult> e : mp.getTQRs().entrySet()) {

--- a/src/main/java/de/learnlib/ralib/learning/rastar/Row.java
+++ b/src/main/java/de/learnlib/ralib/learning/rastar/Row.java
@@ -158,9 +158,9 @@ public class Row implements PrefixContainer {
             return false;
         }
 
-        for (SymbolicSuffix s : this.cells.keySet()) {
-            Cell c1 = this.cells.get(s);
-            Cell c2 = other.cells.get(s);
+        for (Map.Entry<SymbolicSuffix, Cell> entry : this.cells.entrySet()) {
+            Cell c1 = entry.getValue();
+            Cell c2 = other.cells.get(entry.getKey());
 
             if (ioMode) {
                 if (c1 == null && c2 == null) {
@@ -189,9 +189,9 @@ public class Row implements PrefixContainer {
             return false;
         }
 
-        for (SymbolicSuffix s : this.cells.keySet()) {
-            Cell c1 = this.cells.get(s);
-            Cell c2 = other.cells.get(s);
+        for (Map.Entry<SymbolicSuffix, Cell> entry : this.cells.entrySet()) {
+            Cell c1 = entry.getValue();
+            Cell c2 = other.cells.get(entry.getKey());
 
             if (ioMode) {
                 if (c1 == null && c2 == null) {

--- a/src/main/java/de/learnlib/ralib/oracles/mto/MultiTheoryBranching.java
+++ b/src/main/java/de/learnlib/ralib/oracles/mto/MultiTheoryBranching.java
@@ -243,16 +243,16 @@ public class MultiTheoryBranching implements Branching {
                 new LinkedHashMap<DataValue[], List<SDTGuard>>(), new DataValue[0], new ArrayList<SDTGuard>(),
                 new ArrayList<Node>());
 
-        for (DataValue[] dvs : tempMap.keySet()) {
+        for (Map.Entry <DataValue[], List<SDTGuard>> entry : tempMap.entrySet()) {
             List<GuardExpression> gExpr = new ArrayList<>();
-            List<SDTGuard> gList = tempMap.get(dvs);
+            List<SDTGuard> gList = entry.getValue();
             for (SDTGuard g : gList) {
                 gExpr.add(renameSuffixValues(g.toExpr()));
             }
             TransitionGuard tg = new TransitionGuard(new Conjunction(gExpr.toArray(new GuardExpression[] {})));
             assert tg != null;
 
-            Word<PSymbolInstance> branch = prefix.append(new PSymbolInstance(action, dvs));
+            Word<PSymbolInstance> branch = prefix.append(new PSymbolInstance(action, entry.getKey()));
             branches.put(branch, tg);
         }
 

--- a/src/main/java/de/learnlib/ralib/theory/equality/EqualityTheory.java
+++ b/src/main/java/de/learnlib/ralib/theory/equality/EqualityTheory.java
@@ -332,9 +332,9 @@ public abstract class EqualityTheory<T> implements Theory<T> {
             WordValuation ifValues, Constants constants) {
         DataType type = currentParam.getType();
         int newDv_i;
-        for (Constant c : constants.keySet()) {
-            if (constants.get(c).equals(newDv)) {
-                return new EqualityGuard(currentParam, c);
+        for (Map.Entry <Constant, DataValue<?>> entry : constants.entrySet()) {
+            if (entry.getValue().equals(newDv)) {
+                return new EqualityGuard(currentParam, entry.getKey());
             }
         }
         if (prefixValues.contains(newDv)) {


### PR DESCRIPTION
It's pointless to create a set of keys of a Java map in situations where
the intent is to do some operation on all entries. It's better to create
the entry set instead and iterate over it directly.