### PR TITLE
Remove or comment out unused code

### DIFF
--- a/src/main/java/de/learnlib/ralib/automata/Transition.java
+++ b/src/main/java/de/learnlib/ralib/automata/Transition.java
@@ -16,7 +16,6 @@
  */
 package de.learnlib.ralib.automata;
 
-import de.learnlib.api.logging.LearnLogger;
 import de.learnlib.ralib.data.Constants;
 import de.learnlib.ralib.data.ParValuation;
 import de.learnlib.ralib.data.VarValuation;
@@ -39,8 +38,6 @@ public class Transition {
 
     protected final Assignment assignment;
 
-    private static final LearnLogger log = LearnLogger.getLogger(Transition.class);
-
     public Transition(ParameterizedSymbol label, TransitionGuard guard,
             RALocation source, RALocation destination, Assignment assignment) {
         this.label = label;
@@ -50,11 +47,7 @@ public class Transition {
         this.assignment = assignment;
     }
 
-    public boolean isEnabled(VarValuation registers,
-            ParValuation parameters, Constants consts) {
-//        log.trace("isEnabled..... registers: {0}", registers.toString());
-//        log.trace(" ...... parameters: {0}", parameters.toString());
-//        log.trace(" ..... constants {0}\n", consts.toString());
+    public boolean isEnabled(VarValuation registers, ParValuation parameters, Constants consts) {
         return guard.isSatisfied(registers, parameters, consts);
     }
 

--- a/src/main/java/de/learnlib/ralib/automata/guards/Conjunction.java
+++ b/src/main/java/de/learnlib/ralib/automata/guards/Conjunction.java
@@ -49,7 +49,6 @@ public class Conjunction extends GuardExpression {
 
     @Override
     public boolean isSatisfied(Mapping<SymbolicDataValue, DataValue<?>> val) {
-        int i = 0;
         for (GuardExpression ge : conjuncts) {
             if (!ge.isSatisfied(val)) {
                 return false;

--- a/src/main/java/de/learnlib/ralib/automata/guards/Disjunction.java
+++ b/src/main/java/de/learnlib/ralib/automata/guards/Disjunction.java
@@ -49,7 +49,6 @@ public class Disjunction extends GuardExpression {
 
     @Override
     public boolean isSatisfied(Mapping<SymbolicDataValue, DataValue<?>> val) {
-        int i = 0;
         for (GuardExpression ge : disjuncts) {
             if (ge.isSatisfied(val)) {
                 return true;

--- a/src/main/java/de/learnlib/ralib/ceanalysis/PrefixFinder.java
+++ b/src/main/java/de/learnlib/ralib/ceanalysis/PrefixFinder.java
@@ -5,9 +5,6 @@ import java.util.LinkedHashSet;
 import java.util.Map;
 import java.util.Set;
 
-import org.apache.commons.lang3.tuple.ImmutablePair;
-import org.apache.commons.lang3.tuple.Pair;
-
 import de.learnlib.api.logging.LearnLogger;
 import de.learnlib.api.query.DefaultQuery;
 import de.learnlib.ralib.automata.TransitionGuard;
@@ -153,24 +150,24 @@ public class PrefixFinder {
 		throw new RuntimeException("should not reach here");
 	}
 
-    private Pair<TreeQueryResult, TreeQueryResult> checkForCE(Word<PSymbolInstance> prefix, SymbolicSuffix suffix, Word<PSymbolInstance> transition) {
-    	SymbolicWord symWord = new SymbolicWord(prefix, suffix);
-    	TreeQueryResult resHyp = hypOracle.treeQuery(prefix, suffix);
-    	TreeQueryResult resSul;
-    	if (storedQueries.containsKey(symWord))
-    		resSul = storedQueries.get(symWord);
-    	else {
-    		resSul = sulOracle.treeQuery(prefix, suffix);
-    		storedQueries.put(symWord, resSul);
-    	}
-
-        boolean hasCE = sdtOracle.hasCounterexample(prefix,
-                resHyp.getSdt(), resHyp.getPiv(),
-                resSul.getSdt(), resSul.getPiv(),
-                new TransitionGuard(), transition);
-
-        return hasCE ? new ImmutablePair<TreeQueryResult, TreeQueryResult>(resHyp, resSul) : null;
-    }
+//    private Pair<TreeQueryResult, TreeQueryResult> checkForCE(Word<PSymbolInstance> prefix, SymbolicSuffix suffix, Word<PSymbolInstance> transition) {
+//    	SymbolicWord symWord = new SymbolicWord(prefix, suffix);
+//    	TreeQueryResult resHyp = hypOracle.treeQuery(prefix, suffix);
+//    	TreeQueryResult resSul;
+//    	if (storedQueries.containsKey(symWord))
+//    		resSul = storedQueries.get(symWord);
+//    	else {
+//    		resSul = sulOracle.treeQuery(prefix, suffix);
+//    		storedQueries.put(symWord, resSul);
+//    	}
+//
+//        boolean hasCE = sdtOracle.hasCounterexample(prefix,
+//                resHyp.getSdt(), resHyp.getPiv(),
+//                resSul.getSdt(), resSul.getPiv(),
+//                new TransitionGuard(), transition);
+//
+//        return hasCE ? new ImmutablePair<TreeQueryResult, TreeQueryResult>(resHyp, resSul) : null;
+//    }
 
     private boolean transitionHasCE(Word<PSymbolInstance> ce, int idx) {
     	if (idx+1 >= ce.length())

--- a/src/main/java/de/learnlib/ralib/ceanalysis/PrefixFinder.java
+++ b/src/main/java/de/learnlib/ralib/ceanalysis/PrefixFinder.java
@@ -45,33 +45,29 @@ public class PrefixFinder {
 
     private final SDTLogicOracle sdtOracle;
 
-    private Map<Word<PSymbolInstance>, LocationComponent> components;
+    //private Map<Word<PSymbolInstance>, LocationComponent> components;
 
     private final Constants consts;
 
     private SymbolicWord[] candidates;
-    private boolean[] isCE;
 
     private final Map<SymbolicWord, TreeQueryResult> candidateCEs = new LinkedHashMap<SymbolicWord, TreeQueryResult>();
-    private final Map<SymbolicWord, TreeQueryResult> discardedCEs = new LinkedHashMap<SymbolicWord, TreeQueryResult>();
-    private final Map<SymbolicWord, TreeQueryResult> usedCEs = new LinkedHashMap<SymbolicWord, TreeQueryResult>();
     private final Map<SymbolicWord, TreeQueryResult> storedQueries = new LinkedHashMap<SymbolicWord, TreeQueryResult>();
 
     private static final LearnLogger log = LearnLogger.getLogger(PrefixFinder.class);
 
     public PrefixFinder(TreeOracle sulOracle, TreeOracle hypOracle,
             Hypothesis hypothesis, SDTLogicOracle sdtOracle,
-            Map<Word<PSymbolInstance>, LocationComponent> components,
+            //Map<Word<PSymbolInstance>, LocationComponent> components,
             Constants consts) {
 
         this.sulOracle = sulOracle;
         this.hypOracle = hypOracle;
         this.hypothesis = hypothesis;
         this.sdtOracle = sdtOracle;
-        this.components = components;
+        //this.components = components;
         this.consts = consts;
     }
-
 
     public CEAnalysisResult analyzeCounterexample(Word<PSymbolInstance> ce) {
 		int idx = findIndex(ce);
@@ -85,8 +81,8 @@ public class PrefixFinder {
         		                                       candidates[idx].getSuffix(),
         		                                       tqr);
 
-		candidateCEs.put(candidates[idx], tqr);
-		storeCandidateCEs(ce, idx);
+        candidateCEs.put(candidates[idx], tqr);
+        storeCandidateCEs(ce, idx);
 
         return result;
     }
@@ -206,9 +202,7 @@ public class PrefixFinder {
 	                new TransitionGuard(), transition);
 
     		if (hasCE) {
-				Word<PSymbolInstance> primeLocation = hypothesis.transformAccessSequence(location);
-				SymbolicWord sw = candidate(location,transition.lastSymbol().getBaseSymbol(),symSuffix, resSul.getSdt(), resSul.getPiv(), resHyp.getSdt(), resHyp.getPiv(), components.get(primeLocation), ce);
-
+				SymbolicWord sw = candidate(location, symSuffix, resSul.getSdt(), resSul.getPiv(), resHyp.getSdt(), resHyp.getPiv(), ce);
 				// new by falk
 				candidates[idx+1] = sw;
 				return true;
@@ -237,8 +231,8 @@ public class PrefixFinder {
     }
 
     private SymbolicWord candidate(Word<PSymbolInstance> prefix,
-            ParameterizedSymbol action, SymbolicSuffix symSuffix, SymbolicDecisionTree sdtSul, PIV pivSul,
-            SymbolicDecisionTree sdtHyp, PIV pivHyp, LocationComponent c, Word<PSymbolInstance> ce) {
+            SymbolicSuffix symSuffix, SymbolicDecisionTree sdtSul, PIV pivSul,
+            SymbolicDecisionTree sdtHyp, PIV pivHyp, Word<PSymbolInstance> ce) {
     	Word<PSymbolInstance> candidate = null;
 
     	GuardExpression expr = sdtOracle.getCEGuard(prefix, sdtSul, pivSul, sdtHyp, pivHyp);
@@ -299,7 +293,7 @@ public class PrefixFinder {
     	this.hypothesis = hyp;
     }
 
-    public void setComponents(Map<Word<PSymbolInstance>, LocationComponent> components) {
-    	this.components = components;
-    }
+    //public void setComponents(Map<Word<PSymbolInstance>, LocationComponent> components) {
+    //    this.components = components;
+    //}
 }

--- a/src/main/java/de/learnlib/ralib/dt/DTLeaf.java
+++ b/src/main/java/de/learnlib/ralib/dt/DTLeaf.java
@@ -151,8 +151,7 @@ public class DTLeaf extends DTNode implements LocationComponent {
     MappedPrefix getMappedPrefix(Word<PSymbolInstance> p) {
         if (access.getPrefix().equals(p))
             return access;
-        MappedPrefix ret = null;
-        ret = shortPrefixes.get(p);
+        MappedPrefix ret = shortPrefixes.get(p);
         if (ret != null)
             return ret;
         ret = otherPrefixes.get(p);
@@ -218,12 +217,11 @@ public class DTLeaf extends DTNode implements LocationComponent {
     }
 
     public MappedPrefix getPrefix(Word<PSymbolInstance> prefix) {
-    	MappedPrefix mp = null;
     	if (getAccessSequence().equals(prefix))
-    		return getPrimePrefix();
-    	mp = shortPrefixes.get(prefix);
+            return getPrimePrefix();
+        MappedPrefix mp = shortPrefixes.get(prefix);
     	if (mp == null)
-    		mp = otherPrefixes.get(prefix);
+            mp = otherPrefixes.get(prefix);
     	return mp;
     }
 

--- a/src/main/java/de/learnlib/ralib/equivalence/IOEquivalenceTest.java
+++ b/src/main/java/de/learnlib/ralib/equivalence/IOEquivalenceTest.java
@@ -231,7 +231,7 @@ public class IOEquivalenceTest implements IOEquivalenceOracle
             RegisterAutomaton a, Collection<? extends PSymbolInstance> clctn) {
 
         this.sys2 = a;
-        int x=0;
+        //int x = 0;
 
         LinkedList<Triple> q = new LinkedList<>();
         Triple start = new Triple(sys1.getInitialState(), sys2.getInitialState(),
@@ -256,7 +256,8 @@ public class IOEquivalenceTest implements IOEquivalenceOracle
                 }
 
                 List<Word<PSymbolInstance>> words =
-                        getNext(t.as, ps, t.sys1reg, t.sys2reg, checkForEqualParameters);
+                        getNext(t.as, ps, t.sys1reg, //t.sys2reg,
+				checkForEqualParameters);
 
                 for (Word<PSymbolInstance> w : words)
                 {
@@ -282,9 +283,9 @@ public class IOEquivalenceTest implements IOEquivalenceOracle
                     }
                     // FIXME: this may not be OK in general. I think it is ok
                     // for learning ....
-                    if (hasDoubles(next.sys2reg)) {
-                        continue;
-                    }
+                    //if (hasDoubles(next.sys2reg)) {
+                    //    continue;
+                    //}
 
                     st = new Tuple(next.sys1loc, next.sys2loc, next.sys1reg, next.sys2reg);
                     ArrayList<Tuple> comp = visited.get(st);
@@ -319,18 +320,15 @@ public class IOEquivalenceTest implements IOEquivalenceOracle
                 }
             }
 
-            x++;
-
+            //x++;
         }
 
         return null;
     }
 
-    private static boolean hasDoubles(VarValuation r) {
-        return false;
-
+//    private static boolean hasDoubles(VarValuation r) {
 //        Set<Object> s = new LinkedHashSet<>();
-//        int x=0;
+//        int x = 0;
 //        for (String key : r.getKeys()) {
 //            if (!key.startsWith("r")) {
 //                continue;
@@ -342,8 +340,7 @@ public class IOEquivalenceTest implements IOEquivalenceOracle
 //            }
 //        }
 //        return (s.size() != x);
-    }
-
+//    }
 
     private Pair<PSymbolInstance, PSymbolInstance> executeStep(
             Triple in, PSymbolInstance psi, Triple out)
@@ -421,7 +418,7 @@ public class IOEquivalenceTest implements IOEquivalenceOracle
 
 
     private List<Word<PSymbolInstance>> getNext(Word<PSymbolInstance> w,
-            ParameterizedSymbol ps, VarValuation r1, VarValuation r2,
+            ParameterizedSymbol ps, VarValuation r1, //VarValuation r2,
             boolean checkForEqualParameters) {
 
         Set<DataValue<?>> potential = new LinkedHashSet<>();

--- a/src/main/java/de/learnlib/ralib/equivalence/IORandomWalk.java
+++ b/src/main/java/de/learnlib/ralib/equivalence/IORandomWalk.java
@@ -172,7 +172,7 @@ public class IORandomWalk implements IOEquivalenceOracle {
     }
 
     private PSymbolInstance nextInput(Word<PSymbolInstance> run) {
-        ParameterizedSymbol ps = nextSymbol(run);
+        ParameterizedSymbol ps = nextSymbol();
         PSymbolInstance psi = nextDataValues(run, ps);
         return psi;
     }
@@ -215,7 +215,7 @@ public class IORandomWalk implements IOEquivalenceOracle {
         return new PSymbolInstance(ps, vals);
     }
 
-    private ParameterizedSymbol nextSymbol(Word<PSymbolInstance> run) {
+    private ParameterizedSymbol nextSymbol() {
         ParameterizedSymbol ps = null;
         Map<DataType, Integer> tCount = new LinkedHashMap<>();
         if (uniform) {

--- a/src/main/java/de/learnlib/ralib/equivalence/RAEquivalenceTest.java
+++ b/src/main/java/de/learnlib/ralib/equivalence/RAEquivalenceTest.java
@@ -50,30 +50,6 @@ public class RAEquivalenceTest implements IOEquivalenceOracle
 {
 
     /* **********************************************************************
-     * object pairs ...
-     */
-
-    private static class Pair<T1, T2> {
-
-        private final T1 first;
-        private final T2 second;
-
-        public Pair(T1 first, T2 second) {
-            this.first = first;
-            this.second = second;
-        }
-
-        public T1 getFirst() {
-            return first;
-        }
-
-        public T2 getSecond() {
-            return second;
-        }
-    }
-
-
-    /* **********************************************************************
      * state pair hash stuff ...
      */
 
@@ -274,7 +250,6 @@ public class RAEquivalenceTest implements IOEquivalenceOracle
 
                     // found counterexample
                     if (next.sys1loc.isAccepting() != next.sys2loc.isAccepting()) {
-                        //System.out.println("CE: " + out.getFirst() + " : " + out.getSecond());
                         return new DefaultQuery<>(next.trace, next.sys1loc.isAccepting());
                     }
                     // FIXME: this may not be OK in general. I think it is ok

--- a/src/main/java/de/learnlib/ralib/equivalence/RAEquivalenceTest.java
+++ b/src/main/java/de/learnlib/ralib/equivalence/RAEquivalenceTest.java
@@ -232,7 +232,7 @@ public class RAEquivalenceTest implements IOEquivalenceOracle
             RegisterAutomaton a, Collection<? extends PSymbolInstance> clctn) {
 
         this.sys2 = a;
-        int x=0;
+        //int x = 0;
 
         LinkedList<Triple> q = new LinkedList<>();
         Triple start = new Triple(sys1.getInitialState(), sys2.getInitialState(),
@@ -258,7 +258,7 @@ public class RAEquivalenceTest implements IOEquivalenceOracle
             {
 
                 List<Word<PSymbolInstance>> words =
-                        getNext(t.as, ps, t.sys1reg, t.sys2reg, checkForEqualParameters);
+                        getNext(t.as, ps, t.sys1reg, checkForEqualParameters);
 
                 for (Word<PSymbolInstance> w : words)
                 {
@@ -279,9 +279,9 @@ public class RAEquivalenceTest implements IOEquivalenceOracle
                     }
                     // FIXME: this may not be OK in general. I think it is ok
                     // for learning ....
-                    if (hasDoubles(next.sys2reg)) {
-                        continue;
-                    }
+                    //if (hasDoubles(next.sys2reg)) {
+                    //    continue;
+                    //}
 
                     st = new Tuple(next.sys1loc, next.sys2loc, next.sys1reg, next.sys2reg);
                     ArrayList<Tuple> comp = visited.get(st);
@@ -312,19 +312,18 @@ public class RAEquivalenceTest implements IOEquivalenceOracle
                     q.add(next);
                     visited.get(st).add(st);
                     //log.trace("added " + w + " to queue");
-
                 }
             }
 
-            x++;
+            //x++;
 
         }
 
         return null;
     }
 
-    private static boolean hasDoubles(VarValuation r) {
-        return false;
+//    private static boolean hasDoubles(VarValuation r) {
+//        return false;
 
 //        Set<Object> s = new LinkedHashSet<>();
 //        int x=0;
@@ -339,12 +338,9 @@ public class RAEquivalenceTest implements IOEquivalenceOracle
 //            }
 //        }
 //        return (s.size() != x);
-    }
+//    }
 
-
-    private void executeStep(
-            Triple in, PSymbolInstance psi, Triple out)
-    {
+    private void executeStep(Triple in, PSymbolInstance psi, Triple out) {
         out.sys1reg = new VarValuation(in.sys1reg);
         out.sys2reg = new VarValuation(in.sys2reg);
 
@@ -389,7 +385,7 @@ public class RAEquivalenceTest implements IOEquivalenceOracle
 
 
     private List<Word<PSymbolInstance>> getNext(Word<PSymbolInstance> w,
-            ParameterizedSymbol ps, VarValuation r1, VarValuation r2,
+            ParameterizedSymbol ps, VarValuation r1,
             boolean checkForEqualParameters) {
 
         Set<DataValue<?>> potential = new LinkedHashSet<>();

--- a/src/main/java/de/learnlib/ralib/learning/CounterexampleAnalysis.java
+++ b/src/main/java/de/learnlib/ralib/learning/CounterexampleAnalysis.java
@@ -71,7 +71,6 @@ public class CounterexampleAnalysis {
     public CEAnalysisResult analyzeCounterexample(Word<PSymbolInstance> ce) {
 
         int idx = binarySearch(ce);
-        //int idx = linearBackWardsSearch(ce);
 
         Word<PSymbolInstance> prefix = ce.prefix(idx);
         Word<PSymbolInstance> suffix = ce.suffix(ce.length() -idx);
@@ -177,42 +176,6 @@ public class CounterexampleAnalysis {
         }
 
         return true;
-    }
-
-    private int linearBackWardsSearch(Word<PSymbolInstance> ce) {
-
-        assert ce.length() > 1;
-
-        IndexResult[] results = new IndexResult[ce.length()];
-        results[ce.length()-1] = IndexResult.NO_CE;
-
-        int idx = ce.length()-2;
-
-        while (idx >= 0) {
-            IndexResult res = computeIndex(ce, idx);
-            results[idx] = res;
-            if (res != IndexResult.NO_CE) {
-                break;
-            }
-            idx--;
-        }
-
-        assert (idx >= 0);
-
-        // if in the last step there was no counterexample,
-        // we have to move one step to the left
-        if (results[idx] == IndexResult.NO_CE) {
-            assert idx > 0;
-            idx--;
-        }
-
-        // if the current index has no refinement use the
-        // suffix of the next index
-        if (results[idx] == IndexResult.HAS_CE_NO_REFINE) {
-            idx++;
-        }
-
-        return idx;
     }
 
     private int binarySearch(Word<PSymbolInstance> ce) {

--- a/src/main/java/de/learnlib/ralib/learning/CounterexampleAnalysis.java
+++ b/src/main/java/de/learnlib/ralib/learning/CounterexampleAnalysis.java
@@ -71,6 +71,7 @@ public class CounterexampleAnalysis {
     public CEAnalysisResult analyzeCounterexample(Word<PSymbolInstance> ce) {
 
         int idx = binarySearch(ce);
+        //int idx = linearBackWardsSearch(ce);
 
         Word<PSymbolInstance> prefix = ce.prefix(idx);
         Word<PSymbolInstance> suffix = ce.suffix(ce.length() -idx);
@@ -177,6 +178,42 @@ public class CounterexampleAnalysis {
 
         return true;
     }
+
+//    private int linearBackWardsSearch(Word<PSymbolInstance> ce) {
+//
+//        assert ce.length() > 1;
+//
+//        IndexResult[] results = new IndexResult[ce.length()];
+//        results[ce.length()-1] = IndexResult.NO_CE;
+//
+//        int idx = ce.length()-2;
+//
+//        while (idx >= 0) {
+//            IndexResult res = computeIndex(ce, idx);
+//            results[idx] = res;
+//            if (res != IndexResult.NO_CE) {
+//                break;
+//            }
+//            idx--;
+//        }
+//
+//        assert (idx >= 0);
+//
+//        // if in the last step there was no counterexample,
+//        // we have to move one step to the left
+//        if (results[idx] == IndexResult.NO_CE) {
+//            assert idx > 0;
+//            idx--;
+//        }
+//
+//        // if the current index has no refinement use the
+//        // suffix of the next index
+//        if (results[idx] == IndexResult.HAS_CE_NO_REFINE) {
+//            idx++;
+//        }
+//
+//        return idx;
+//    }
 
     private int binarySearch(Word<PSymbolInstance> ce) {
 

--- a/src/main/java/de/learnlib/ralib/learning/SymbolicWord.java
+++ b/src/main/java/de/learnlib/ralib/learning/SymbolicWord.java
@@ -18,7 +18,6 @@ import net.automatalib.words.Word;
 public class SymbolicWord {
 	private Word<PSymbolInstance> prefix;
 	private SymbolicSuffix suffix;
-	private Word<PSymbolInstance> concreteSuffix = null;
 
 	public SymbolicWord(Word<PSymbolInstance> prefix, SymbolicSuffix suffix) {
 		this.prefix = prefix;
@@ -31,20 +30,6 @@ public class SymbolicWord {
 
 	public SymbolicSuffix getSuffix() {
 		return suffix;
-	}
-
-	public Word<PSymbolInstance> concretize(Word<PSymbolInstance> word, Hypothesis hyp) {
-		int len = word.length() - suffix.length();
-//		Word<PSymbolInstance> cp = word.prefix(len);
-//		Word<PSymbolInstance> cs = word.suffix(suffix.length());
-
-		Word<PSymbolInstance> concereteSuffix = prefix.concat(Word.epsilon());
-		for (int idx = len; idx < word.length(); idx++) {
-			Word<PSymbolInstance> cp = word.prefix(idx);
-
-		}
-
-		return null;
 	}
 
 	public Mapping<SymbolicDataValue, DataValue<?>> computeValuation(Word<PSymbolInstance> concreteSuffix, PIV piv) {

--- a/src/main/java/de/learnlib/ralib/learning/ralambda/RaLambda.java
+++ b/src/main/java/de/learnlib/ralib/learning/ralambda/RaLambda.java
@@ -139,7 +139,7 @@ public class RaLambda implements RaLearningAlgorithm {
         hyp = (DTHyp) ab.toRegisterAutomaton();
         if (prefixFinder != null) {
         	prefixFinder.setHypothesis(hyp);
-        	prefixFinder.setComponents(components);
+                //prefixFinder.setComponents(components);
         	prefixFinder.setHypothesisTreeOracle(hypOracleFactory.createTreeOracle(hyp));
         }
     }
@@ -164,9 +164,9 @@ public class RaLambda implements RaLearningAlgorithm {
         TreeOracle hypOracle = hypOracleFactory.createTreeOracle(hyp);
 
         if (prefixFinder == null) {
-        	Map<Word<PSymbolInstance>, LocationComponent> components = new LinkedHashMap<Word<PSymbolInstance>, LocationComponent>();
-        	components.putAll(dt.getComponents());
-            prefixFinder = new PrefixFinder(sulOracle, hypOracle, hyp, sdtLogicOracle, components, consts);
+            //Map<Word<PSymbolInstance>, LocationComponent> components = new LinkedHashMap<Word<PSymbolInstance>, LocationComponent>();
+            //components.putAll(dt.getComponents());
+            prefixFinder = new PrefixFinder(sulOracle, hypOracle, hyp, sdtLogicOracle, consts);
         }
 
         boolean foundce = false;
@@ -343,7 +343,7 @@ public class RaLambda implements RaLearningAlgorithm {
             	continue;
             }
 
-            Word<PSymbolInstance> branch = branchWithSameGuard(dest_c.getPrefix(word), src_c.getPrefix(src_id), hypBranching);
+            Word<PSymbolInstance> branch = branchWithSameGuard(dest_c.getPrefix(word), hypBranching);
             DTLeaf branchLeaf = dt.getLeaf(branch);
 
             SymbolicSuffix suffix = null;
@@ -445,7 +445,7 @@ public class RaLambda implements RaLearningAlgorithm {
         this.useOldAnalyzer = useOldAnalyzer;
     }
 
-    private Word<PSymbolInstance> branchWithSameGuard(MappedPrefix mp, MappedPrefix src_id, Branching branching) {
+    private Word<PSymbolInstance> branchWithSameGuard(MappedPrefix mp, Branching branching) {
     	Word<PSymbolInstance> dw = mp.getPrefix();
 
     	return branching.transformPrefix(dw);

--- a/src/main/java/de/learnlib/ralib/learning/rastar/Row.java
+++ b/src/main/java/de/learnlib/ralib/learning/rastar/Row.java
@@ -63,13 +63,13 @@ public class Row implements PrefixContainer {
         this.ioMode = ioMode;
     }
 
-    private Row(Word<PSymbolInstance> prefix, List<Cell> cells, boolean ioMode) {
-        this(prefix, ioMode);
-
-        for (Cell c : cells) {
-            this.cells.put(c.getSuffix(), c);
-        }
-    }
+//    private Row(Word<PSymbolInstance> prefix, List<Cell> cells, boolean ioMode) {
+//        this(prefix, ioMode);
+//
+//        for (Cell c : cells) {
+//            this.cells.put(c.getSuffix(), c);
+//        }
+//    }
 
     void addSuffix(SymbolicSuffix suffix, TreeOracle oracle) {
         if (ioMode && suffix.getActions().length() > 0) {

--- a/src/main/java/de/learnlib/ralib/oracles/mto/MultiTheoryTreeOracle.java
+++ b/src/main/java/de/learnlib/ralib/oracles/mto/MultiTheoryTreeOracle.java
@@ -84,8 +84,6 @@ public class MultiTheoryTreeOracle implements TreeOracle, SDTConstructor {
 
     private final ConstraintSolver solver;
 
-    private final MultiTheorySDTLogicOracle logicOracle;
-
     private static LearnLogger log = LearnLogger.getLogger(MultiTheoryTreeOracle.class);
 
     public MultiTheoryTreeOracle(DataWordOracle oracle, Map<DataType, Theory> teachers, Constants constants,
@@ -94,7 +92,6 @@ public class MultiTheoryTreeOracle implements TreeOracle, SDTConstructor {
         this.teachers = teachers;
         this.constants = constants;
         this.solver = solver;
-        this.logicOracle = new MultiTheorySDTLogicOracle(constants, solver);
     }
 
     @Override
@@ -134,7 +131,7 @@ public class MultiTheoryTreeOracle implements TreeOracle, SDTConstructor {
         if (values.size() == DataWords.paramLength(suffix.getActions())) {
             Word<PSymbolInstance> concSuffix = DataWords.instantiate(suffix.getActions(), values);
 
-            Word<PSymbolInstance> trace = prefix.concat(concSuffix);
+//            Word<PSymbolInstance> trace = prefix.concat(concSuffix);
             DefaultQuery<PSymbolInstance, Boolean> query = new DefaultQuery<>(prefix, concSuffix);
             oracle.processQueries(Collections.singletonList(query));
             boolean qOut = query.getOutput();
@@ -267,11 +264,9 @@ public class MultiTheoryTreeOracle implements TreeOracle, SDTConstructor {
             for (Map.Entry<SDTGuard, Set<SDTGuard>> mergedGuardEntry : mergedGuards.entrySet()) {
                 SDTGuard guard = mergedGuardEntry.getKey();
                 Set<SDTGuard> oldGuards = mergedGuardEntry.getValue();
-                DataValue dvi = null;
 
                 // first solve using a constraint solver
-                dvi = teach.instantiate(prefix, ps, piv, pval, constants, guard, p, oldDvs);
-
+                DataValue dvi = teach.instantiate(prefix, ps, piv, pval, constants, guard, p, oldDvs);
                 // if merging of guards is done properly, there should be no case where the
                 // guard cannot be instantiated.
                 assert (dvi != null);

--- a/src/main/java/de/learnlib/ralib/oracles/mto/OptimizedSymbolicSuffixBuilder.java
+++ b/src/main/java/de/learnlib/ralib/oracles/mto/OptimizedSymbolicSuffixBuilder.java
@@ -185,7 +185,7 @@ public class OptimizedSymbolicSuffixBuilder {
     	int actionArity = actionSymbol.getArity();
     	int suffixArity = DataWords.paramLength(suffixActions);
     	DataType[] suffixDataTypes = dataTypes(suffixActions);
-    	Map<Register, SuffixValue> actionParameters = buildParameterMap(sub, action, piv);
+        Map<Register, SuffixValue> actionParameters = buildParameterMap(sub, piv);
 
     	Set<SuffixValue> freeValues = new LinkedHashSet<>();
     	Map<Integer, SuffixValue> dataValues = new LinkedHashMap<>();
@@ -278,7 +278,7 @@ public class OptimizedSymbolicSuffixBuilder {
     	return dts;
     }
 
-    private Map<Register, SuffixValue> buildParameterMap(Word<PSymbolInstance> prefix, PSymbolInstance action, PIV piv) {
+    private Map<Register, SuffixValue> buildParameterMap(Word<PSymbolInstance> prefix, PIV piv) {
     	int arity = DataWords.paramValLength(prefix);
     	Map<Register, SuffixValue> actionParameters = new LinkedHashMap<>();
     	for (Map.Entry<Parameter, Register> e : piv.entrySet()) {

--- a/src/main/java/de/learnlib/ralib/oracles/mto/OptimizedSymbolicSuffixBuilder.java
+++ b/src/main/java/de/learnlib/ralib/oracles/mto/OptimizedSymbolicSuffixBuilder.java
@@ -10,7 +10,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import de.learnlib.api.logging.LearnLogger;
 import de.learnlib.ralib.automata.guards.Conjunction;
 import de.learnlib.ralib.automata.guards.GuardExpression;
 import de.learnlib.ralib.data.Constants;
@@ -40,8 +39,6 @@ import net.automatalib.words.Word;
 public class OptimizedSymbolicSuffixBuilder {
 
     private final Constants consts;
-
-    private static LearnLogger log = LearnLogger.getLogger(OptimizedSymbolicSuffixBuilder.class);
 
     public OptimizedSymbolicSuffixBuilder(Constants consts) {
         this.consts = consts;

--- a/src/main/java/de/learnlib/ralib/oracles/mto/SDT.java
+++ b/src/main/java/de/learnlib/ralib/oracles/mto/SDT.java
@@ -392,13 +392,11 @@ public class SDT implements SymbolicDecisionTree {
         if (paths.isEmpty()) {
             return FalseGuardExpression.FALSE;
         }
-        Set<SuffixValue> svals = new LinkedHashSet<>();
         GuardExpression dis = null;
         for (List<SDTGuard> list : paths) {
             List<GuardExpression> expr = new ArrayList<>();
             for (SDTGuard g : list) {
                 expr.add(g.toExpr());
-                svals.add(g.getParameter());
             }
             Conjunction con = new Conjunction(
                     expr.toArray(new GuardExpression[] {}));
@@ -415,13 +413,11 @@ public class SDT implements SymbolicDecisionTree {
         if (paths.isEmpty()) {
             return FalseGuardExpression.FALSE;
         }
-        Set<SuffixValue> svals = new LinkedHashSet<>();
         GuardExpression dis = null;
         for (List<SDTGuard> list : paths) {
             List<GuardExpression> expr = new ArrayList<>();
             for (SDTGuard g : list) {
                 expr.add(g.toExpr());
-                svals.add(g.getParameter());
             }
             Conjunction con = new Conjunction(
                     expr.toArray(new GuardExpression[] {}));
@@ -439,13 +435,11 @@ public class SDT implements SymbolicDecisionTree {
     		expressions.put(FalseGuardExpression.FALSE, false);
     		return expressions;
     	}
-    	Set<SuffixValue> svals = new LinkedHashSet<>();
     	for (Map.Entry<List<SDTGuard>, Boolean> e : paths.entrySet()) {
     		List<SDTGuard> list = e.getKey();
     		List<GuardExpression> expr = new ArrayList<>();
     		for (SDTGuard g : list) {
     			expr.add(g.toExpr());
-    			svals.add(g.getParameter());
     		}
     		Conjunction con = new Conjunction(
     				expr.toArray(new GuardExpression[] {}));

--- a/src/main/java/de/learnlib/ralib/solver/simple/TranslationContext.java
+++ b/src/main/java/de/learnlib/ralib/solver/simple/TranslationContext.java
@@ -71,11 +71,11 @@ public class TranslationContext {
 		throw new IllegalArgumentException();
 	}
 
-	private Constraint translate(TrueGuardExpression e) {
+	private Constraint translate(TrueGuardExpression unused) {
 		return Constraint.TRUE;
 	}
 
-	private Constraint translate(FalseGuardExpression e) {
+	private Constraint translate(FalseGuardExpression unused) {
 		return Constraint.FALSE;
 	}
 

--- a/src/main/java/de/learnlib/ralib/sul/SULOracle.java
+++ b/src/main/java/de/learnlib/ralib/sul/SULOracle.java
@@ -59,7 +59,7 @@ public class SULOracle extends IOOracle {
             PSymbolInstance in = applyReplacements(act.getSymbol(i));
 
             PSymbolInstance out = sul.step(in);
-            updateReplacements(act.getSymbol(i + 1), out);
+            updateReplacements(out);
 
             trace = trace.append(in).append(out);
 
@@ -94,9 +94,7 @@ public class SULOracle extends IOOracle {
         return new PSymbolInstance(symbol.getBaseSymbol(), vals);
     }
 
-    private void updateReplacements(
-            PSymbolInstance outTest, PSymbolInstance outSys) {
-
+    private void updateReplacements(PSymbolInstance outSys) {
         for (int i = 0; i < outSys.getBaseSymbol().getArity(); i++) {
             Set<DataValue> set = getOrCreate(outSys.getParameterValues()[i]);
             set.add(outSys.getParameterValues()[i]);

--- a/src/main/java/de/learnlib/ralib/theory/equality/UniqueEqualityTheory.java
+++ b/src/main/java/de/learnlib/ralib/theory/equality/UniqueEqualityTheory.java
@@ -18,21 +18,21 @@ import net.automatalib.words.Word;
 
 public abstract class UniqueEqualityTheory<T> implements Theory<T> {
 
-    protected boolean useNonFreeOptimization;
+    // protected boolean useNonFreeOptimization;
 
-    protected boolean freshValues = false;
+    // protected boolean freshValues = false;
 
-    protected IOOracle ioOracle;
+    // protected IOOracle ioOracle;
 
     private static final LearnLogger log = LearnLogger.getLogger(EqualityTheory.class);
 
     public UniqueEqualityTheory(boolean useNonFreeOptimization) {
-        this.useNonFreeOptimization = useNonFreeOptimization;
+        // this.useNonFreeOptimization = useNonFreeOptimization;
     }
 
     public void setFreshValues(boolean freshValues, IOOracle ioOracle) {
-        this.ioOracle = ioOracle;
-        this.freshValues = freshValues;
+        // this.ioOracle = ioOracle;
+        // this.freshValues = freshValues;
     }
 
     public UniqueEqualityTheory() {

--- a/src/main/java/de/learnlib/ralib/theory/inequality/InequalityTheoryWithEq.java
+++ b/src/main/java/de/learnlib/ralib/theory/inequality/InequalityTheoryWithEq.java
@@ -156,7 +156,6 @@ public abstract class InequalityTheoryWithEq<T> implements Theory<T> {
                 addSafely(guards, t, regPotential);
             }
         }
-        return;
     }
 
     private void addSafely(Collection<SDTGuard> guards, SDTGuard guard, List<SymbolicDataValue> regPotential) {
@@ -191,7 +190,6 @@ public abstract class InequalityTheoryWithEq<T> implements Theory<T> {
             guards.add(guard);
         }
 //        System.out.println("added safely: " + guard + " to " + guards);
-        return;
     }
 
     private void removeProhibited(Collection<SDTGuard> guards, Collection<SDTGuard> prohibited) {
@@ -201,7 +199,6 @@ public abstract class InequalityTheoryWithEq<T> implements Theory<T> {
             }
         }
         //System.out.println("guards after removing " + prohibited + " :: " + guards);
-        return;
     }
 
 //    private Set<SDTGuard> mergeSetWithSet(Set<SDTGuard> guardSet, Set<SDTGuard> targets, Set<SDTGuard> prohibited) {

--- a/src/main/java/de/learnlib/ralib/theory/inequality/InequalityTheoryWithEq.java
+++ b/src/main/java/de/learnlib/ralib/theory/inequality/InequalityTheoryWithEq.java
@@ -529,7 +529,7 @@ public abstract class InequalityTheoryWithEq<T> implements Theory<T> {
             assert headSDT.getClass().equals(refSDT.getClass());
             //assert !(headSDT.isEmpty());
             //assert !(refSDT.isEmpty());
-            SDTGuard headGuard = headList.get(0);
+            //SDTGuard headGuard = headList.get(0);
             SDT newSDT = headSDT;
 //            System.out.println("head: " + newHeadList + " against " + refGuard);
             if (headSDT instanceof SDTLeaf) {

--- a/src/main/java/de/learnlib/ralib/theory/inequality/IntervalGuard.java
+++ b/src/main/java/de/learnlib/ralib/theory/inequality/IntervalGuard.java
@@ -32,7 +32,6 @@ import de.learnlib.ralib.data.SymbolicDataValue;
 import de.learnlib.ralib.data.SymbolicDataValue.SuffixValue;
 import de.learnlib.ralib.data.VarMapping;
 import de.learnlib.ralib.theory.SDTGuard;
-import de.learnlib.ralib.theory.SDTOrGuard;
 import de.learnlib.ralib.theory.equality.DisequalityGuard;
 import de.learnlib.ralib.theory.equality.EqualityGuard;
 
@@ -252,16 +251,16 @@ public class IntervalGuard extends SDTGuard {
 
     }
 
-    private Set<SDTGuard> mergeWithEquality(EqualityGuard other) {
-        Set<SDTGuard> guards = new LinkedHashSet<>();
-        if (!(other.getRegister().equals(this.leftLimit) || other.getRegister().equals(this.rightLimit))) {
-            guards.add(this);
-            guards.add(other);
-        } else {
-            guards.add(new SDTOrGuard(this.parameter, this, other));
-        }
-        return guards;
-    }
+//    private Set<SDTGuard> mergeWithEquality(EqualityGuard other) {
+//        Set<SDTGuard> guards = new LinkedHashSet<>();
+//        if (!(other.getRegister().equals(this.leftLimit) || other.getRegister().equals(this.rightLimit))) {
+//            guards.add(this);
+//            guards.add(other);
+//        } else {
+//            guards.add(new SDTOrGuard(this.parameter, this, other));
+//        }
+//        return guards;
+//    }
 
     @Override
     public Set<SDTGuard> mergeWith(SDTGuard other, List<SymbolicDataValue> regPotential) {

--- a/src/main/java/de/learnlib/ralib/tools/IOSimulator.java
+++ b/src/main/java/de/learnlib/ralib/tools/IOSimulator.java
@@ -303,10 +303,9 @@ public class IOSimulator extends AbstractToolWithRandomWalk {
             SimpleProfiler.stop(__LEARN__);
             SimpleProfiler.start(__EQ__);
             DefaultQuery<PSymbolInstance, Boolean> ce  = null;
-            DefaultQuery<PSymbolInstance, Boolean> origCe  = null;
 
             if (useEqTest) {
-                ce = this.eqTest.findCounterExample(hyp, null);
+                ce = this.eqTest.findCounterExample(hyp, new ArrayList<>());
 
                 if (ce != null) {
                     eqTestfoundCE = true;
@@ -328,7 +327,7 @@ public class IOSimulator extends AbstractToolWithRandomWalk {
 
                 DefaultQuery<PSymbolInstance, Boolean> ce2 = null;
 
-                ce2 = (findCounterexamples ? this.randomWalk.findCounterExample(hyp, null) : ce);
+                ce2 = (findCounterexamples ? this.randomWalk.findCounterExample(hyp, new ArrayList<>()) : ce);
 
                 SimpleProfiler.stop(__SEARCH__);
                 System.out.println("CE: " + ce2);

--- a/src/main/java/de/learnlib/ralib/tools/theories/UniqueIntegerEqualityTheory.java
+++ b/src/main/java/de/learnlib/ralib/tools/theories/UniqueIntegerEqualityTheory.java
@@ -12,7 +12,6 @@ import de.learnlib.ralib.tools.classanalyzer.TypedTheory;
 
 public class UniqueIntegerEqualityTheory extends UniqueEqualityTheory<Integer> implements TypedTheory<Integer> {
 
-
     private DataType type = null;
 
     public UniqueIntegerEqualityTheory() {
@@ -38,8 +37,8 @@ public class UniqueIntegerEqualityTheory extends UniqueEqualityTheory<Integer> i
     }
 
     @Override
-    public void setUseSuffixOpt(boolean useit) {
-        this.useNonFreeOptimization = useit;
+    public void setUseSuffixOpt(boolean unused) {
+        // this.useNonFreeOptimization = unused;
     }
 
     @Override

--- a/src/main/java/de/learnlib/ralib/words/DataWords.java
+++ b/src/main/java/de/learnlib/ralib/words/DataWords.java
@@ -161,12 +161,8 @@ public final class DataWords {
             DataValue[] pvalues = new DataValue[ps.getArity()];
             for (int i = 0; i < ps.getArity(); i++) {
                 pvalues[i] = dataValues.get(pid++);
-                //log.trace(pvalues[i].toString());
             }
             symbols[idx++] = new PSymbolInstance(ps, pvalues);
-        }
-        for (PSymbolInstance p : symbols) {
-            //log.trace(p.toString());
         }
         return Word.fromSymbols(symbols);
     }
@@ -189,12 +185,8 @@ public final class DataWords {
             DataValue[] pvalues = new DataValue[ps.getArity()];
             for (int i = 0; i < ps.getArity(); i++) {
                 pvalues[i] = dataValues[pid++ -1];
-                //log.trace(pvalues[i].toString());
             }
             symbols[idx++] = new PSymbolInstance(ps, pvalues);
-        }
-        for (PSymbolInstance p : symbols) {
-            //log.trace(p.toString());
         }
         return Word.fromSymbols(symbols);
     }

--- a/src/test/java/de/learnlib/ralib/ceanalysis/PrefixFinderTest.java
+++ b/src/test/java/de/learnlib/ralib/ceanalysis/PrefixFinderTest.java
@@ -95,7 +95,7 @@ public class PrefixFinderTest extends RaLibTestSuite {
                 mto,
                 hypFactory.createTreeOracle(hyp), hyp,
                 slo,
-                rastar.getComponents(),
+                // rastar.getComponents(),
                 consts
         );
 
@@ -143,7 +143,7 @@ public class PrefixFinderTest extends RaLibTestSuite {
                 mto,
                 hypFactory.createTreeOracle(hyp), hyp,
                 slo,
-                ralambda.getComponents(),
+                // ralambda.getComponents(),
                 consts
         );
 

--- a/src/test/java/de/learnlib/ralib/data/PIVRemappingIteratorTest.java
+++ b/src/test/java/de/learnlib/ralib/data/PIVRemappingIteratorTest.java
@@ -54,7 +54,7 @@ public class PIVRemappingIteratorTest extends RaLibTestSuite {
         PIV piv2 = generatePIV(new PIV(), type1, 4);
 
         int count = 0;
-        for (VarMapping map : new PIVRemappingIterator(piv1, piv2)) {
+        for (VarMapping unused : new PIVRemappingIterator(piv1, piv2)) {
             count++;
         }
 
@@ -74,8 +74,7 @@ public class PIVRemappingIteratorTest extends RaLibTestSuite {
         piv2 = generatePIV(piv2, type2, 2);
 
         int count = 0;
-        for (VarMapping map : new PIVRemappingIterator(piv1, piv2)) {
-            //System.out.println(map);
+        for (VarMapping unused : new PIVRemappingIterator(piv1, piv2)) {
             count++;
         }
 

--- a/src/test/java/de/learnlib/ralib/data/PermutationIteratorTest.java
+++ b/src/test/java/de/learnlib/ralib/data/PermutationIteratorTest.java
@@ -32,10 +32,10 @@ public class PermutationIteratorTest extends RaLibTestSuite {
     public void testIterator() {
 
         int expected = 0;
-        for (int i=0; i<10; i++) {
+        for (int i = 0; i < 10; i++) {
             int count = 0;
             PermutationIterator iter = new PermutationIterator(i);
-            for (int[] xx : iter) {
+            for (int[] unused : iter) {
                 count++;
             }
             Assert.assertEquals(expected, count);

--- a/src/test/java/de/learnlib/ralib/dt/DTInnerNodeTest.java
+++ b/src/test/java/de/learnlib/ralib/dt/DTInnerNodeTest.java
@@ -19,7 +19,6 @@ import de.learnlib.ralib.data.PIV;
 import de.learnlib.ralib.learning.SymbolicSuffix;
 import de.learnlib.ralib.oracles.DataWordOracle;
 import de.learnlib.ralib.oracles.SimulatorOracle;
-import de.learnlib.ralib.oracles.TreeQueryResult;
 import de.learnlib.ralib.oracles.mto.MultiTheoryTreeOracle;
 import de.learnlib.ralib.solver.ConstraintSolver;
 import de.learnlib.ralib.solver.simple.SimpleConstraintSolver;
@@ -30,59 +29,51 @@ import net.automatalib.words.Word;
 
 public class DTInnerNodeTest {
 
-  @Test
-  public void siftTest() {
+    @Test
+    public void siftTest() {
 
-      RegisterAutomaton sul = AUTOMATON;
-      DataWordOracle dwOracle = new SimulatorOracle(sul);
+        RegisterAutomaton sul = AUTOMATON;
+        DataWordOracle dwOracle = new SimulatorOracle(sul);
 
-      final Map<DataType, Theory> teachers = new LinkedHashMap<>();
-      teachers.put(T_INT, new IntegerEqualityTheory(T_INT));
+        final Map<DataType, Theory> teachers = new LinkedHashMap<>();
+        teachers.put(T_INT, new IntegerEqualityTheory(T_INT));
 
-      ConstraintSolver solver = new SimpleConstraintSolver();
+        ConstraintSolver solver = new SimpleConstraintSolver();
 
-      MultiTheoryTreeOracle mto = new MultiTheoryTreeOracle(
-              dwOracle, teachers, new Constants(), solver);
+        MultiTheoryTreeOracle mto = new MultiTheoryTreeOracle(
+            dwOracle, teachers, new Constants(), solver);
 
-      Word<PSymbolInstance> p1 = Word.fromSymbols(
-              new PSymbolInstance(I_PUSH,
-                      new DataValue(T_INT, 1)),
-              new PSymbolInstance(I_POP,
-                      new DataValue(T_INT, 1)));
+        Word<PSymbolInstance> p1 = Word.fromSymbols(
+            new PSymbolInstance(I_PUSH, new DataValue(T_INT, 1)),
+            new PSymbolInstance(I_POP, new DataValue(T_INT, 1)));
 
-      Word<PSymbolInstance> p2 = Word.fromSymbols(
-              new PSymbolInstance(I_PUSH,
-                      new DataValue(T_INT, 1)),
-              new PSymbolInstance(I_PUSH,
-                      new DataValue(T_INT, 2)));
+        Word<PSymbolInstance> p2 = Word.fromSymbols(
+            new PSymbolInstance(I_PUSH, new DataValue(T_INT, 1)),
+            new PSymbolInstance(I_PUSH, new DataValue(T_INT, 2)));
 
-      Word<PSymbolInstance> epsilon = Word.epsilon();
-      Word<PSymbolInstance> push = Word.fromSymbols(
-    		  new PSymbolInstance(I_PUSH,
-    				  new DataValue(T_INT, 1)));
+        Word<PSymbolInstance> epsilon = Word.epsilon();
+        Word<PSymbolInstance> push = Word.fromSymbols(
+            new PSymbolInstance(I_PUSH, new DataValue(T_INT, 1)));
 
-      Word<PSymbolInstance> suffix = Word.fromSymbols(
-    		  new PSymbolInstance(I_POP,
-    				  new DataValue(T_INT, 1)));
+        Word<PSymbolInstance> suffix = Word.fromSymbols(
+            new PSymbolInstance(I_POP, new DataValue(T_INT, 1)));
 
-      SymbolicSuffix symbSuffix = new SymbolicSuffix(epsilon, suffix);
+        SymbolicSuffix symbSuffix = new SymbolicSuffix(epsilon, suffix);
 
-      DTInnerNode node = new DTInnerNode(symbSuffix);
-      DTLeaf child1 = new DTLeaf(new MappedPrefix(epsilon, new PIV()), mto);
-      DTLeaf child2 = new DTLeaf(new MappedPrefix(push, new PIV()), mto);
+        DTInnerNode node = new DTInnerNode(symbSuffix);
+        DTLeaf child1 = new DTLeaf(new MappedPrefix(epsilon, new PIV()), mto);
+        DTLeaf child2 = new DTLeaf(new MappedPrefix(push, new PIV()), mto);
 
-      TreeQueryResult tqr1 = mto.treeQuery(epsilon, symbSuffix);
-      PathResult r1 = PathResult.computePathResult(mto, new MappedPrefix(epsilon, new PIV()), node.getSuffixes(), false);
-      TreeQueryResult tqr2 = mto.treeQuery(push, symbSuffix);
-      PathResult r2 = PathResult.computePathResult(mto, new MappedPrefix(push, new PIV()), node.getSuffixes(), false);
+        PathResult r1 = PathResult.computePathResult(mto, new MappedPrefix(epsilon, new PIV()), node.getSuffixes(), false);
+        PathResult r2 = PathResult.computePathResult(mto, new MappedPrefix(push, new PIV()), node.getSuffixes(), false);
 
-      node.addBranch(new DTBranch(child1, r1));
-      node.addBranch(new DTBranch(child2, r2));
+        node.addBranch(new DTBranch(child1, r1));
+        node.addBranch(new DTBranch(child2, r2));
 
-      DTNode test1 = node.sift(new MappedPrefix(p1, new PIV()), mto, false).getKey();
-      DTNode test2 = node.sift(new MappedPrefix(p2, new PIV()), mto, false).getKey();
+        DTNode test1 = node.sift(new MappedPrefix(p1, new PIV()), mto, false).getKey();
+        DTNode test2 = node.sift(new MappedPrefix(p2, new PIV()), mto, false).getKey();
 
-      Assert.assertEquals(test1, child1);
-      Assert.assertEquals(test2, child2);
+        Assert.assertEquals(test1, child1);
+        Assert.assertEquals(test2, child2);
     }
 }

--- a/src/test/java/de/learnlib/ralib/dt/DTTest.java
+++ b/src/test/java/de/learnlib/ralib/dt/DTTest.java
@@ -51,8 +51,6 @@ public class DTTest {
 		TreeQueryResult tqrEps = oracle.treeQuery(epsilon, suffPop);
 		TreeQueryResult tqrPush = oracle.treeQuery(prePush, suffPush);
 		TreeQueryResult tqrPushPush = oracle.treeQuery(prePushPush, suffPush);
-		TreeQueryResult tqrInnerPop = oracle.treeQuery(epsilon, suffEps);
-		TreeQueryResult tqrInnerPush = oracle.treeQuery(prePush, suffPop);
 
 		DTInnerNode nodeEps = new DTInnerNode(suffEps);
 		DTInnerNode nodePop = new DTInnerNode(suffPop);
@@ -104,7 +102,6 @@ public class DTTest {
 
 		TreeQueryResult tqrPop = oracle.treeQuery(prePop, suffEps);
 		TreeQueryResult tqrEps = oracle.treeQuery(epsilon, suffPop);
-		TreeQueryResult tqrInnerPop = oracle.treeQuery(epsilon, suffEps);
 
 		DTInnerNode nodeEps = new DTInnerNode(suffEps);
 		DTInnerNode nodePop = new DTInnerNode(suffPop);

--- a/src/test/java/de/learnlib/ralib/example/priority/PriorityQueueOracle.java
+++ b/src/test/java/de/learnlib/ralib/example/priority/PriorityQueueOracle.java
@@ -58,7 +58,6 @@ public final class PriorityQueueOracle implements DataWordOracle {
                 query.answer(true);
             } else {
                 PriorityQueue<BigDecimal> queue = new PriorityQueue<>();
-                PSymbolInstance[] trace = new PSymbolInstance[query.getInput().length()];
                 Boolean[] answer = new Boolean[query.getInput().length()];
 
                 for (int i = 0; i < query.getInput().length(); i++) {

--- a/src/test/java/de/learnlib/ralib/learning/SymbolicSuffixTest.java
+++ b/src/test/java/de/learnlib/ralib/learning/SymbolicSuffixTest.java
@@ -2,27 +2,17 @@ package de.learnlib.ralib.learning;
 
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
-import java.util.Map;
-import java.util.logging.Level;
 
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
 import de.learnlib.ralib.RaLibTestSuite;
 import de.learnlib.ralib.TestUtil;
-import de.learnlib.ralib.automata.RegisterAutomaton;
 import de.learnlib.ralib.automata.xml.RegisterAutomatonImporter;
 import de.learnlib.ralib.data.Constants;
 import de.learnlib.ralib.data.DataType;
 import de.learnlib.ralib.data.DataValue;
 import de.learnlib.ralib.data.SymbolicDataValue.SuffixValue;
-import de.learnlib.ralib.oracles.mto.MultiTheoryTreeOracle;
-import de.learnlib.ralib.solver.simple.SimpleConstraintSolver;
-import de.learnlib.ralib.sul.DataWordSUL;
-import de.learnlib.ralib.sul.SimulatorSUL;
-import de.learnlib.ralib.theory.Theory;
-import de.learnlib.ralib.tools.classanalyzer.TypedTheory;
-import de.learnlib.ralib.tools.theories.IntegerEqualityTheory;
 import de.learnlib.ralib.words.DataWords;
 import de.learnlib.ralib.words.InputSymbol;
 import de.learnlib.ralib.words.OutputSymbol;
@@ -35,27 +25,13 @@ public class SymbolicSuffixTest extends RaLibTestSuite {
   @Test
   public void concatTest() {
 
-	  RegisterAutomatonImporter loader = TestUtil.getLoader(
+      RegisterAutomatonImporter loader = TestUtil.getLoader(
               "/de/learnlib/ralib/automata/xml/fifo7.xml");
 
-      RegisterAutomaton model = loader.getRegisterAutomaton();
-      logger.log(Level.FINE, "SYS: {0}", model);
-
-      ParameterizedSymbol[] inputs = loader.getInputs().toArray(
-              new ParameterizedSymbol[]{});
+      //RegisterAutomaton model = loader.getRegisterAutomaton();
+      //logger.log(Level.FINE, "SYS: {0}", model);
 
       Constants consts = loader.getConstants();
-
-      final Map<DataType, Theory> teachers = new LinkedHashMap<>();
-      loader.getDataTypes().stream().forEach((t) -> {
-          TypedTheory<Integer> theory = new IntegerEqualityTheory(t);
-          theory.setUseSuffixOpt(true);
-          teachers.put(t, theory);
-      });
-
-      DataWordSUL sul = new SimulatorSUL(model, teachers, consts);
-      MultiTheoryTreeOracle mto = TestUtil.createMTO(sul, ERROR,
-              teachers, consts, new SimpleConstraintSolver(), inputs);
 
       DataType intType = TestUtil.getType("int", loader.getDataTypes());
 
@@ -65,23 +41,22 @@ public class SymbolicSuffixTest extends RaLibTestSuite {
       ParameterizedSymbol iget = new InputSymbol(
               "IGet", new DataType[] {});
 
-       ParameterizedSymbol oget = new OutputSymbol(
+      ParameterizedSymbol oget = new OutputSymbol(
               "OGet", new DataType[] {intType});
 
-       ParameterizedSymbol ook = new OutputSymbol(
+      ParameterizedSymbol ook = new OutputSymbol(
               "OOK", new DataType[] {});
 
-       DataValue d0 = new DataValue(intType, 0);
-       DataValue d1 = new DataValue(intType, 1);
-       DataValue d6 = new DataValue(intType, 6);
+      DataValue d0 = new DataValue(intType, 0);
+      DataValue d1 = new DataValue(intType, 1);
+      DataValue d6 = new DataValue(intType, 6);
 
       //****** IPut[0[int]] OOK[] IPut[1[int]] OOK[]
       Word<PSymbolInstance> prefix1 = Word.fromSymbols(
               new PSymbolInstance(iput,d0),
-              new PSymbolInstance(ook)
-              ,new PSymbolInstance(iput,d1),
-              new PSymbolInstance(ook)
-              );
+              new PSymbolInstance(ook),
+              new PSymbolInstance(iput,d1),
+              new PSymbolInstance(ook));
 
       //**** [s2, s3, s4, s5]((IPut[s1] OOK[] IPut[s2] OOK[] IGet[] OGet[s3] IGet[] OGet[s4] IGet[] OGet[s1] IGet[] OGet[s5]))
       Word<PSymbolInstance> suffix1 =  Word.fromSymbols(
@@ -89,8 +64,6 @@ public class SymbolicSuffixTest extends RaLibTestSuite {
               new PSymbolInstance(ook),
               new PSymbolInstance(iput,d0),
               new PSymbolInstance(ook));
-
-
 
       Word<PSymbolInstance> prefix2 = Word.fromSymbols(new PSymbolInstance(iget),
       new PSymbolInstance(oget,d0),

--- a/src/test/java/de/learnlib/ralib/learning/ralambda/LearnDtlsServerTest.java
+++ b/src/test/java/de/learnlib/ralib/learning/ralambda/LearnDtlsServerTest.java
@@ -1,6 +1,5 @@
 package de.learnlib.ralib.learning.ralambda;
 
-
 import java.util.LinkedHashMap;
 import java.util.Map;
 
@@ -34,8 +33,8 @@ public class LearnDtlsServerTest extends RaLibTestSuite {
 
         RegisterAutomaton model = loader.getRegisterAutomaton();
 
-        ParameterizedSymbol[] inputs = loader.getInputs().toArray(
-                new ParameterizedSymbol[]{});
+//        ParameterizedSymbol[] inputs = loader.getInputs().toArray(
+//                new ParameterizedSymbol[]{});
 
         ParameterizedSymbol[] actions = loader.getActions().toArray(
                 new ParameterizedSymbol[]{});

--- a/src/test/java/de/learnlib/ralib/learning/ralambda/LearnPQIOTest.java
+++ b/src/test/java/de/learnlib/ralib/learning/ralambda/LearnPQIOTest.java
@@ -62,7 +62,7 @@ public class LearnPQIOTest extends RaLibTestSuite {
 
         long seed = -4750580074638681533L;
         logger.log(Level.FINE, "SEED={0}", seed);
-        final Random random = new Random(seed);
+        final Random unused = new Random(seed);
 
         final Map<DataType, Theory> teachers = new LinkedHashMap<>();
         teachers.put(PriorityQueueSUL.DOUBLE_TYPE,
@@ -82,7 +82,6 @@ public class LearnPQIOTest extends RaLibTestSuite {
         );
 
         Assert.assertNull(checker.findCounterExample(hyp, null));
-
     }
 
     @Test

--- a/src/test/java/de/learnlib/ralib/learning/ralambda/LearnPQTest.java
+++ b/src/test/java/de/learnlib/ralib/learning/ralambda/LearnPQTest.java
@@ -141,7 +141,7 @@ public class LearnPQTest extends RaLibTestSuite {
 //        runner.setUseOldAnalyzer(true);
 
         Measurements[] ralambdaCount = new Measurements [SEEDS];
-        Measurements[] rastarCount = new Measurements [SEEDS];
+//        Measurements[] rastarCount = new Measurements [SEEDS];
         for (int i=0; i<SEEDS; i++) {
             System.out.println(i);
             runner.setSeed(i);

--- a/src/test/java/de/learnlib/ralib/learning/ralambda/LearnSipIOTest.java
+++ b/src/test/java/de/learnlib/ralib/learning/ralambda/LearnSipIOTest.java
@@ -42,13 +42,13 @@ import de.learnlib.ralib.words.ParameterizedSymbol;
 import net.automatalib.words.Word;
 
 public class LearnSipIOTest extends RaLibTestSuite {
-	@Test
-	public void learnSipIO() {
+    @Test
+    public void learnSipIO() {
 
         long seed = -1386796323025681754L;
         //long seed = (new Random()).nextLong();
         logger.log(Level.FINE, "SEED={0}", seed);
-        final Random random = new Random(seed);
+        final Random unused = new Random(seed);
 
         RegisterAutomatonImporter loader = TestUtil.getLoader(
                 "/de/learnlib/ralib/automata/xml/sip.xml");
@@ -62,7 +62,6 @@ public class LearnSipIOTest extends RaLibTestSuite {
                 new ParameterizedSymbol[]{});
 
         final Constants consts = loader.getConstants();
-
 
         final Map<DataType, Theory> teachers = new LinkedHashMap<>();
         loader.getDataTypes().stream().forEach((t) -> {
@@ -133,9 +132,8 @@ public class LearnSipIOTest extends RaLibTestSuite {
 
         RegisterAutomaton hyp = ralambda.getHypothesis();
         logger.log(Level.FINE, "FINAL HYP: {0}", hyp);
-        DefaultQuery<PSymbolInstance, Boolean> ce =
-            ioEquiv.findCounterExample(hyp, null);
+        DefaultQuery<PSymbolInstance, Boolean> ce = ioEquiv.findCounterExample(hyp, null);
 
         Assert.assertNull(ce);
-	}
+    }
 }

--- a/src/test/java/de/learnlib/ralib/learning/ralambda/LearnStackTest.java
+++ b/src/test/java/de/learnlib/ralib/learning/ralambda/LearnStackTest.java
@@ -246,7 +246,7 @@ public class LearnStackTest extends RaLibTestSuite {
             Assert.assertEquals(hypLambda.getStates().size(), 4);
             Assert.assertEquals(hypLambda.getTransitions().size(), 10);
 
-            Hypothesis hypStar = runner.run(RaLearningAlgorithmName.RASTAR, dwOracle, teachers, consts, solver, new ParameterizedSymbol[] {I_PUSH, I_POP});
+            runner.run(RaLearningAlgorithmName.RASTAR, dwOracle, teachers, consts, solver, new ParameterizedSymbol[] {I_PUSH, I_POP});
             measuresStar[seed] = runner.getMeasurements();
             runner.resetMeasurements();
         }

--- a/src/test/java/de/learnlib/ralib/learning/ralambda/TestUnknownMemorable.java
+++ b/src/test/java/de/learnlib/ralib/learning/ralambda/TestUnknownMemorable.java
@@ -305,7 +305,7 @@ public class TestUnknownMemorable extends RaLibTestSuite {
 			Matcher m = dvPattern.matcher(ceString);
 			Collection<Integer> params = new ArrayList<Integer>();
 			while (m.find()) {
-				String s = m.group(1);
+				//String s = m.group(1);
 				params.add(Integer.parseInt(m.group(1)));
 			}
 

--- a/src/test/java/de/learnlib/ralib/learning/rastar/LearnSipIOTest.java
+++ b/src/test/java/de/learnlib/ralib/learning/rastar/LearnSipIOTest.java
@@ -66,7 +66,7 @@ public class LearnSipIOTest extends RaLibTestSuite {
         long seed = -1386796323025681754L;
         //long seed = (new Random()).nextLong();
         logger.log(Level.FINE, "SEED={0}", seed);
-        final Random random = new Random(seed);
+        final Random unused = new Random(seed);
 
         RegisterAutomatonImporter loader = TestUtil.getLoader(
                 "/de/learnlib/ralib/automata/xml/sip.xml");
@@ -80,7 +80,6 @@ public class LearnSipIOTest extends RaLibTestSuite {
                 new ParameterizedSymbol[]{});
 
         final Constants consts = loader.getConstants();
-
 
         final Map<DataType, Theory> teachers = new LinkedHashMap<>();
         loader.getDataTypes().stream().forEach((t) -> {
@@ -110,8 +109,7 @@ public class LearnSipIOTest extends RaLibTestSuite {
 
         RaStar rastar = new RaStar(mto, hypFactory, mlo, consts, true, actions);
 
-            IOEquivalenceTest ioEquiv = new IOEquivalenceTest(
-                    model, teachers, consts, true, actions);
+        IOEquivalenceTest ioEquiv = new IOEquivalenceTest(model, teachers, consts, true, actions);
 
         IOCounterexampleLoopRemover loops = new IOCounterexampleLoopRemover(ioOracle);
         IOCounterExamplePrefixReplacer asrep = new IOCounterExamplePrefixReplacer(ioOracle);

--- a/src/test/java/de/learnlib/ralib/oracles/mto/ConstantsSDTBranchingTest.java
+++ b/src/test/java/de/learnlib/ralib/oracles/mto/ConstantsSDTBranchingTest.java
@@ -57,7 +57,6 @@ public class ConstantsSDTBranchingTest extends RaLibTestSuite {
         RegisterAutomatonImporter loader = TestUtil.getLoader(
                 "/de/learnlib/ralib/automata/xml/abp.output.xml");
 
-
         RegisterAutomaton model = loader.getRegisterAutomaton();
         logger.log(Level.FINE, "SYS: {0}", model);
 
@@ -77,8 +76,8 @@ public class ConstantsSDTBranchingTest extends RaLibTestSuite {
 
         DataType intType = TestUtil.getType("int", loader.getDataTypes());
 
-        ParameterizedSymbol iack = new InputSymbol(
-                "IAck", new DataType[] {intType});
+        //ParameterizedSymbol iack = new InputSymbol(
+        //        "IAck", new DataType[] {intType});
 
         ParameterizedSymbol iin = new InputSymbol(
                 "IIn", new DataType[] {intType});
@@ -93,7 +92,7 @@ public class ConstantsSDTBranchingTest extends RaLibTestSuite {
                 "OFrame", new DataType[] {intType, intType});
 
         DataValue d2 = new DataValue(intType, 2);
-        DataValue c1 = new DataValue(intType, 0);
+        //DataValue c1 = new DataValue(intType, 0);
 
         //****** ROW:  IIn OOK ISendFrame
         Word<PSymbolInstance> prefix = Word.fromSymbols(
@@ -106,15 +105,8 @@ public class ConstantsSDTBranchingTest extends RaLibTestSuite {
                 new PSymbolInstance(oframe, d2, d2));
         SymbolicSuffix symSuffix1 = new SymbolicSuffix(prefix, suffix1);
 
-        Word<PSymbolInstance> test =  Word.fromSymbols(
-                new PSymbolInstance(iin, d2),
-                new PSymbolInstance(ook),
-                new PSymbolInstance(isend),
-                new PSymbolInstance(oframe, d2, c1));
-
         logger.log(Level.FINE, "Prefix: {0}", prefix);
         logger.log(Level.FINE, "Suffix: {0}", symSuffix1);
-
 
         TreeQueryResult tqr = mto.treeQuery(prefix, symSuffix1);
         logger.log(Level.FINE, "PIV: {0}", tqr.getPiv());
@@ -128,6 +120,5 @@ public class ConstantsSDTBranchingTest extends RaLibTestSuite {
         Assert.assertEquals(b.getBranches().size(), 3);
         Assert.assertEquals(bString, expected);
     }
-
 
 }

--- a/src/test/java/de/learnlib/ralib/oracles/mto/FreshValuesTest.java
+++ b/src/test/java/de/learnlib/ralib/oracles/mto/FreshValuesTest.java
@@ -60,7 +60,6 @@ public class FreshValuesTest extends RaLibTestSuite {
         RegisterAutomatonImporter loader = TestUtil.getLoader(
                 "/de/learnlib/ralib/automata/xml/keygen.xml");
 
-
         RegisterAutomaton model = loader.getRegisterAutomaton();
         logger.log(Level.FINE, "SYS: {0}", model);
 
@@ -96,18 +95,18 @@ public class FreshValuesTest extends RaLibTestSuite {
         ParameterizedSymbol iget = new InputSymbol(
                 "IGet", new DataType[] {intType});
 
-         ParameterizedSymbol oput = new OutputSymbol(
+        ParameterizedSymbol oput = new OutputSymbol(
                 "OPut", new DataType[] {intType});
 
-         ParameterizedSymbol oget = new OutputSymbol(
-                "OGet", new DataType[] {intType});
+//        ParameterizedSymbol oget = new OutputSymbol(
+//                "OGet", new DataType[] {intType});
 
-         ParameterizedSymbol onok = new OutputSymbol(
+        ParameterizedSymbol onok = new OutputSymbol(
                 "ONOK", new DataType[] {});
 
-         DataValue d0 = new DataValue(intType, 0);
-         DataValue d1 = new DataValue(intType, 1);
-         DataValue d2 = new DataValue(intType, 2);
+        DataValue d0 = new DataValue(intType, 0);
+        DataValue d1 = new DataValue(intType, 1);
+        DataValue d2 = new DataValue(intType, 2);
 
         // IPut[0[int]] OPut[1[int]] IGet[2[int]] ONOK[] [p2>r1,p1>r2,p3>r3,] []
         Word<PSymbolInstance> prefix1 = Word.fromSymbols(
@@ -116,9 +115,9 @@ public class FreshValuesTest extends RaLibTestSuite {
                 new PSymbolInstance(iget, d2),
                 new PSymbolInstance(onok));
 
-         DataValue d3 = new DataValue(intType, 3);
-         DataValue d4 = new DataValue(intType, 4);
-         DataValue d5 = new DataValue(intType, 5);
+        DataValue d3 = new DataValue(intType, 3);
+        DataValue d4 = new DataValue(intType, 4);
+        DataValue d5 = new DataValue(intType, 5);
 
         // [s2, s4]((IGet[s1] ONOK[] IPut[s2] OPut[s3] IGet[s4] ONOK[] IPut[s5] ONOK[]))
         Word<PSymbolInstance> suffix = Word.fromSymbols(
@@ -130,7 +129,6 @@ public class FreshValuesTest extends RaLibTestSuite {
                 new PSymbolInstance(onok),
                 new PSymbolInstance(iput, d5),
                 new PSymbolInstance(onok));
-
 
         SymbolicSuffix symSuffix = new SymbolicSuffix(prefix1, suffix);
 

--- a/src/test/java/de/learnlib/ralib/oracles/mto/InstantiateSymbolicWordTest.java
+++ b/src/test/java/de/learnlib/ralib/oracles/mto/InstantiateSymbolicWordTest.java
@@ -43,7 +43,6 @@ public class InstantiateSymbolicWordTest {
 
     @Test
     public void testInstantiateStack() {
-        Constants consts = new Constants();
         RegisterAutomaton sul = AUTOMATON;
         DataWordOracle dwOracle = new SimulatorOracle(sul);
 

--- a/src/test/java/de/learnlib/ralib/oracles/mto/InstantiateSymbolicWordTest.java
+++ b/src/test/java/de/learnlib/ralib/oracles/mto/InstantiateSymbolicWordTest.java
@@ -29,9 +29,7 @@ import de.learnlib.ralib.data.VarMapping;
 import de.learnlib.ralib.data.util.SymbolicDataValueGenerator;
 import de.learnlib.ralib.learning.SymbolicSuffix;
 import de.learnlib.ralib.oracles.DataWordOracle;
-import de.learnlib.ralib.oracles.SDTLogicOracle;
 import de.learnlib.ralib.oracles.SimulatorOracle;
-import de.learnlib.ralib.oracles.TreeOracleFactory;
 import de.learnlib.ralib.oracles.TreeQueryResult;
 import de.learnlib.ralib.solver.ConstraintSolver;
 import de.learnlib.ralib.solver.simple.SimpleConstraintSolver;
@@ -42,25 +40,20 @@ import de.learnlib.ralib.words.PSymbolInstance;
 import net.automatalib.words.Word;
 
 public class InstantiateSymbolicWordTest {
-	@Test
-	public void testInstantiateStack() {
-		Constants consts = new Constants();
-	    RegisterAutomaton sul = AUTOMATON;
-	    DataWordOracle dwOracle = new SimulatorOracle(sul);
 
-	    final Map<DataType, Theory> teachers = new LinkedHashMap<>();
-	    teachers.put(T_INT, new IntegerEqualityTheory(T_INT));
+    @Test
+    public void testInstantiateStack() {
+        Constants consts = new Constants();
+        RegisterAutomaton sul = AUTOMATON;
+        DataWordOracle dwOracle = new SimulatorOracle(sul);
 
-	    ConstraintSolver solver = new SimpleConstraintSolver();
+        final Map<DataType, Theory> teachers = new LinkedHashMap<>();
+        teachers.put(T_INT, new IntegerEqualityTheory(T_INT));
 
-	    MultiTheoryTreeOracle mto = new MultiTheoryTreeOracle(
+        ConstraintSolver solver = new SimpleConstraintSolver();
+
+        MultiTheoryTreeOracle mto = new MultiTheoryTreeOracle(
 	              dwOracle, teachers, new Constants(), solver);
-
-        SDTLogicOracle slo = new MultiTheorySDTLogicOracle(consts, solver);
-
-        TreeOracleFactory hypFactory = (RegisterAutomaton hyp) ->
-                new MultiTheoryTreeOracle(new SimulatorOracle(hyp), teachers,
-                        new Constants(), solver);
 
         Word<PSymbolInstance> prefix = Word.fromSymbols(
         		new PSymbolInstance(I_PUSH, new DataValue(T_INT, 0)));
@@ -95,35 +88,35 @@ public class InstantiateSymbolicWordTest {
         		words.containsKey(p2) &&
         		words.containsKey(p3));
         Assert.assertTrue(words.get(p1).booleanValue());
-	}
+    }
 
-	@Test
-	public void testInstantiateWithSuffixOpt() {
-		MutableRegisterAutomaton ra = new MutableRegisterAutomaton();
+    @Test
+    public void testInstantiateWithSuffixOpt() {
+        MutableRegisterAutomaton ra = new MutableRegisterAutomaton();
 
-		InputSymbol A = new InputSymbol("a", new DataType[] {T_INT});
-		InputSymbol B = new InputSymbol("b", new DataType[] {T_INT});
+        InputSymbol A = new InputSymbol("a", new DataType[] {T_INT});
+        InputSymbol B = new InputSymbol("b", new DataType[] {T_INT});
 
-		RALocation l0 = ra.addInitialState();
-		RALocation l1 = ra.addState();
-		RALocation ls = ra.addState(false);
+        RALocation l0 = ra.addInitialState();
+        RALocation l1 = ra.addState();
+        RALocation ls = ra.addState(false);
 
-		// registers and parameters
-		SymbolicDataValueGenerator.RegisterGenerator rgen = new SymbolicDataValueGenerator.RegisterGenerator();
-		SymbolicDataValue.Register r1 = rgen.next(T_INT);
-		SymbolicDataValueGenerator.ParameterGenerator pgen = new SymbolicDataValueGenerator.ParameterGenerator();
-		SymbolicDataValue.Parameter p1 = pgen.next(T_INT);
+        // registers and parameters
+        SymbolicDataValueGenerator.RegisterGenerator rgen = new SymbolicDataValueGenerator.RegisterGenerator();
+        SymbolicDataValue.Register r1 = rgen.next(T_INT);
+        SymbolicDataValueGenerator.ParameterGenerator pgen = new SymbolicDataValueGenerator.ParameterGenerator();
+        SymbolicDataValue.Parameter p1 = pgen.next(T_INT);
 
-		// guards
-		GuardExpression equal = new AtomicGuardExpression(r1, Relation.EQUALS, p1);
-		GuardExpression notEqual = new AtomicGuardExpression(r1, Relation.NOT_EQUALS, p1);
+        // guards
+        GuardExpression equal = new AtomicGuardExpression(r1, Relation.EQUALS, p1);
+        GuardExpression notEqual = new AtomicGuardExpression(r1, Relation.NOT_EQUALS, p1);
 
-		TransitionGuard equalGuard = new TransitionGuard(equal);
-		TransitionGuard notEqualGuard = new TransitionGuard(notEqual);
-		TransitionGuard trueGuard = new TransitionGuard();
+        TransitionGuard equalGuard = new TransitionGuard(equal);
+        TransitionGuard notEqualGuard = new TransitionGuard(notEqual);
+        TransitionGuard trueGuard = new TransitionGuard();
 
-		// assignments
-		VarMapping<SymbolicDataValue.Register, SymbolicDataValue> store = new VarMapping<SymbolicDataValue.Register, SymbolicDataValue>();
+        // assignments
+        VarMapping<SymbolicDataValue.Register, SymbolicDataValue> store = new VarMapping<SymbolicDataValue.Register, SymbolicDataValue>();
         store.put(r1, p1);
         VarMapping<Register, SymbolicDataValue> noMapping = new VarMapping<SymbolicDataValue.Register, SymbolicDataValue>();
 
@@ -147,26 +140,26 @@ public class InstantiateSymbolicWordTest {
 
         DataWordOracle dwOracle = new SimulatorOracle(ra);
 
-	    MultiTheoryTreeOracle mto = new MultiTheoryTreeOracle(
-	              dwOracle, teachers, new Constants(), new SimpleConstraintSolver());
+        MultiTheoryTreeOracle mto = new MultiTheoryTreeOracle(
+              dwOracle, teachers, new Constants(), new SimpleConstraintSolver());
 
-	    Word<PSymbolInstance> prefix = Word.fromSymbols(
-	    		new PSymbolInstance(A, new DataValue(T_INT, 0)),
-	    		new PSymbolInstance(B, new DataValue(T_INT, 0)));
-	    Word<PSymbolInstance> suffix = Word.fromSymbols(
-	    		new PSymbolInstance(A, new DataValue(T_INT, 1)),
-	    		new PSymbolInstance(B, new DataValue(T_INT, 1)));
-	    SymbolicSuffix symSuffix = new SymbolicSuffix(prefix, suffix);
+        Word<PSymbolInstance> prefix = Word.fromSymbols(
+              new PSymbolInstance(A, new DataValue(T_INT, 0)),
+              new PSymbolInstance(B, new DataValue(T_INT, 0)));
+        Word<PSymbolInstance> suffix = Word.fromSymbols(
+              new PSymbolInstance(A, new DataValue(T_INT, 1)),
+              new PSymbolInstance(B, new DataValue(T_INT, 1)));
+        SymbolicSuffix symSuffix = new SymbolicSuffix(prefix, suffix);
 
-	    TreeQueryResult tqr = mto.treeQuery(prefix, symSuffix);
-	    Map<Word<PSymbolInstance>, Boolean> words = mto.instantiate(prefix, symSuffix, tqr.getSdt(), tqr.getPiv());
+        TreeQueryResult tqr = mto.treeQuery(prefix, symSuffix);
+        Map<Word<PSymbolInstance>, Boolean> words = mto.instantiate(prefix, symSuffix, tqr.getSdt(), tqr.getPiv());
 
-	    Assert.assertEquals(words.size(), 1);
+        Assert.assertEquals(words.size(), 1);
 
-	    Word<PSymbolInstance> word = words.keySet().iterator().next();
-	    DataValue suffixVal1 = word.getSymbol(2).getParameterValues()[0];
-	    DataValue suffixVal2 = word.getSymbol(3).getParameterValues()[0];
+        Word<PSymbolInstance> word = words.keySet().iterator().next();
+        DataValue suffixVal1 = word.getSymbol(2).getParameterValues()[0];
+        DataValue suffixVal2 = word.getSymbol(3).getParameterValues()[0];
 
-	    Assert.assertEquals(suffixVal1, suffixVal2);
-	}
+        Assert.assertEquals(suffixVal1, suffixVal2);
+    }
 }

--- a/src/test/java/de/learnlib/ralib/oracles/mto/MultiTheorySDTLogicOracleTest.java
+++ b/src/test/java/de/learnlib/ralib/oracles/mto/MultiTheorySDTLogicOracleTest.java
@@ -20,7 +20,6 @@ import de.learnlib.ralib.data.Constants;
 import de.learnlib.ralib.data.DataType;
 import de.learnlib.ralib.data.DataValue;
 import de.learnlib.ralib.learning.SymbolicSuffix;
-import de.learnlib.ralib.oracles.DataWordOracle;
 import de.learnlib.ralib.oracles.SDTLogicOracle;
 import de.learnlib.ralib.oracles.SimulatorOracle;
 import de.learnlib.ralib.oracles.TreeOracle;
@@ -39,7 +38,6 @@ public class MultiTheorySDTLogicOracleTest {
   public void acceptsTest() {
       Constants consts = new Constants();
       RegisterAutomaton sul = AUTOMATON;
-      DataWordOracle dwOracle = new SimulatorOracle(sul);
 
       final Map<DataType, Theory> teachers = new LinkedHashMap<>();
       teachers.put(T_UID, new IntegerEqualityTheory(T_UID));
@@ -47,8 +45,6 @@ public class MultiTheorySDTLogicOracleTest {
 
       ConstraintSolver solver = new SimpleConstraintSolver();
 
-      MultiTheoryTreeOracle mto = new MultiTheoryTreeOracle(
-              dwOracle, teachers, new Constants(), solver);
       SDTLogicOracle slo = new MultiTheorySDTLogicOracle(consts, solver);
 
       TreeOracleFactory hypFactory = (RegisterAutomaton hyp) ->
@@ -79,6 +75,5 @@ public class MultiTheorySDTLogicOracleTest {
           Word<PSymbolInstance> rejectedWord = prefix.concat(rejectedSuffix);
           Assert.assertFalse(slo.accepts(rejectedWord, prefix, query.getSdt(), query.getPiv()));
       }
-
   }
 }

--- a/src/test/java/de/learnlib/ralib/oracles/mto/NonFreeSuffixValuesTest.java
+++ b/src/test/java/de/learnlib/ralib/oracles/mto/NonFreeSuffixValuesTest.java
@@ -60,7 +60,6 @@ import net.automatalib.words.Word;
  */
 public class NonFreeSuffixValuesTest extends RaLibTestSuite {
 
-
     @Test
     public void testModelswithOutputFifo() {
 
@@ -94,15 +93,15 @@ public class NonFreeSuffixValuesTest extends RaLibTestSuite {
         ParameterizedSymbol iget = new InputSymbol(
                 "IGet", new DataType[] {});
 
-         ParameterizedSymbol oget = new OutputSymbol(
+        ParameterizedSymbol oget = new OutputSymbol(
                 "OGet", new DataType[] {intType});
 
-         ParameterizedSymbol ook = new OutputSymbol(
+        ParameterizedSymbol ook = new OutputSymbol(
                 "OOK", new DataType[] {});
 
-         DataValue d0 = new DataValue(intType, 0);
-         DataValue d1 = new DataValue(intType, 1);
-         DataValue d6 = new DataValue(intType, 6);
+        DataValue d0 = new DataValue(intType, 0);
+        DataValue d1 = new DataValue(intType, 1);
+        DataValue d6 = new DataValue(intType, 6);
 
         //****** IPut[0[int]] OOK[] IPut[1[int]] OOK[]
         Word<PSymbolInstance> prefix = Word.fromSymbols(
@@ -242,8 +241,6 @@ public class NonFreeSuffixValuesTest extends RaLibTestSuite {
 
         MultiTheoryTreeOracle mto = new MultiTheoryTreeOracle(
                 oracle, teachers, consts, solver);
-        MultiTheorySDTLogicOracle mlo =
-                new MultiTheorySDTLogicOracle(consts, solver);
 
         Word<PSymbolInstance> word = Word.fromSymbols(
                 new PSymbolInstance(IPUT, new DataValue(TINT, 0)),
@@ -252,7 +249,6 @@ public class NonFreeSuffixValuesTest extends RaLibTestSuite {
                 new PSymbolInstance(OECHO, new DataValue(TINT, 1)),
                 new PSymbolInstance(IPUT, new DataValue(TINT, 2)),
                 new PSymbolInstance(OECHO, new DataValue(TINT, 2)));
-
 
         SymbolicSuffix suffix = new SymbolicSuffix(word.prefix(2), word.suffix(4));
         Assert.assertTrue(suffix.getFreeValues().isEmpty());

--- a/src/test/java/de/learnlib/ralib/oracles/mto/OptimizedSymbolicSuffixBuilderTest.java
+++ b/src/test/java/de/learnlib/ralib/oracles/mto/OptimizedSymbolicSuffixBuilderTest.java
@@ -67,8 +67,7 @@ public class OptimizedSymbolicSuffixBuilderTest {
                 new PSymbolInstance(POP, dv(2)),
                 new PSymbolInstance(CONTAINS, dv(1)));
 
-        equalsSuffixesFromConcretePrefixSuffix(word, mto, consts, solver);
-
+        equalsSuffixesFromConcretePrefixSuffix(word, mto, consts);
 
         InputSymbol A = new InputSymbol("a", INT_TYPE, INT_TYPE);
         InputSymbol B = new InputSymbol("b");
@@ -247,7 +246,7 @@ public class OptimizedSymbolicSuffixBuilderTest {
     /*
      * Checks for equality optimized suffixes built by prepending using an SDT against those built from concrete prefix/suffix
      */
-    private void equalsSuffixesFromConcretePrefixSuffix(Word<PSymbolInstance> word, MultiTheoryTreeOracle mto, Constants consts, ConstraintSolver solver) {
+    private void equalsSuffixesFromConcretePrefixSuffix(Word<PSymbolInstance> word, MultiTheoryTreeOracle mto, Constants consts) {
         OptimizedSymbolicSuffixBuilder builder = new OptimizedSymbolicSuffixBuilder(consts);
         TreeQueryResult tqr = mto.treeQuery(word, new SymbolicSuffix(Word.epsilon()));
         SymbolicSuffix actual = new SymbolicSuffix(word, Word.epsilon());
@@ -266,7 +265,7 @@ public class OptimizedSymbolicSuffixBuilderTest {
     @Test
     public void extendSuffixTest() {
 
-        DataType type = new DataType("int",Integer.class);
+        DataType type = new DataType("int", Integer.class);
         InputSymbol A = new InputSymbol("a", type, type);
         InputSymbol B = new InputSymbol("b", type);
         InputSymbol C = new InputSymbol("c");
@@ -284,7 +283,7 @@ public class OptimizedSymbolicSuffixBuilderTest {
 
         ParameterGenerator pgen = new SymbolicDataValueGenerator.ParameterGenerator();
         Parameter p1 = pgen.next(type);
-        Parameter p2 = pgen.next(type);
+        pgen.next(type);
         Parameter p3 = pgen.next(type);
         Parameter p4 = pgen.next(type);
 
@@ -346,11 +345,10 @@ public class OptimizedSymbolicSuffixBuilderTest {
         sdtPath3.add(new DisequalityGuard(s2, c2));
         sdtPath3.add(new SDTTrueGuard(s3));
         List<List<SDTGuard>> sdtPaths4 = SDTLeaf.ACCEPTING.getPaths(true);
-        List<SDTGuard> sdtPath4 = SDTLeaf.ACCEPTING.getPaths(true).get(0);
+        List<SDTGuard> sdtPath4 = sdtPaths4.get(0);
 
         OptimizedSymbolicSuffixBuilder builder1 = new OptimizedSymbolicSuffixBuilder(consts1);
         OptimizedSymbolicSuffixBuilder builder2 = new OptimizedSymbolicSuffixBuilder(consts2);
-        ConstraintSolver solver = new SimpleConstraintSolver();
 
         SymbolicSuffix expected1 = new SymbolicSuffix(word1.prefix(1), word1.suffix(4), consts1);
         SymbolicSuffix actual1 = builder1.extendSuffix(word1.prefix(2), sdtPath1, piv1, suffix1.getActions());
@@ -362,7 +360,7 @@ public class OptimizedSymbolicSuffixBuilderTest {
 
         SymbolicSuffix expected3 = new SymbolicSuffix(word3.prefix(1), word3.suffix(3), consts2);
         SymbolicSuffix actual3 = builder1.extendSuffix(word3.prefix(2), sdtPath3, piv2, suffix3.getActions());
-        Assert.assertEquals(actual1, expected1);
+        Assert.assertEquals(actual3, expected3);
 
         SymbolicSuffix actual4 = builder2.extendSuffix(word4.prefix(2), sdtPath4, new PIV(), suffix4.getActions());
         Assert.assertEquals(actual4.getFreeValues().size(), 1);

--- a/src/test/java/de/learnlib/ralib/theory/TestTreeOracle.java
+++ b/src/test/java/de/learnlib/ralib/theory/TestTreeOracle.java
@@ -49,7 +49,6 @@ import net.automatalib.words.Word;
 @Test
 public class TestTreeOracle extends RaLibTestSuite {
 
-
     public void testTreeOracle() {
 
         // define types
@@ -66,8 +65,8 @@ public class TestTreeOracle extends RaLibTestSuite {
         final ParameterizedSymbol change = new InputSymbol(
                 "change", new DataType[] {passType});
 
-        final ParameterizedSymbol logout = new InputSymbol(
-                "logout", new DataType[] {userType});
+        //final ParameterizedSymbol logout = new InputSymbol(
+        //        "logout", new DataType[] {userType});
 
         // create prefix: register(falk[userType], secret[passType])
         final Word<PSymbolInstance> prefix = Word.fromLetter(
@@ -80,7 +79,6 @@ public class TestTreeOracle extends RaLibTestSuite {
                     new DataValue(userType, "falk"),
                     new DataValue(passType, "secret"))
                     );
-
 
         // create a symbolic suffix from the concrete suffix
         // symbolic data values: s1, s2 (userType, passType)
@@ -96,7 +94,6 @@ public class TestTreeOracle extends RaLibTestSuite {
             public void processQueries(Collection<? extends Query<PSymbolInstance, Boolean>> clctn) {
 
                 // given a collection of queries, process each one (with Bool replies)
-
                 for (Query q : clctn) {
                     Word<PSymbolInstance> trace = q.getInput();
 
@@ -131,7 +128,6 @@ public class TestTreeOracle extends RaLibTestSuite {
             public Collection<DataValue<String>> getAllNextValues(List<DataValue<String>> vals) {
                 throw new UnsupportedOperationException("Not supported yet.");
             }
-
 
         };
 
@@ -177,7 +173,5 @@ public class TestTreeOracle extends RaLibTestSuite {
         logger.log(Level.FINE, "final SDT: \n{0}", tree);
 
     }
-
-
 
 }

--- a/src/test/java/de/learnlib/ralib/theory/TestTreeOracle.java
+++ b/src/test/java/de/learnlib/ralib/theory/TestTreeOracle.java
@@ -62,8 +62,8 @@ public class TestTreeOracle extends RaLibTestSuite {
         final ParameterizedSymbol login = new InputSymbol(
                 "login", new DataType[] {userType, passType});
 
-        final ParameterizedSymbol change = new InputSymbol(
-                "change", new DataType[] {passType});
+        //final ParameterizedSymbol change = new InputSymbol(
+        //        "change", new DataType[] {passType});
 
         //final ParameterizedSymbol logout = new InputSymbol(
         //        "logout", new DataType[] {userType});


### PR DESCRIPTION
It is no surprise that there is a lot of unused/unnecessary code in the code base.
Such code was due to either attempts to fix things that did not lead anywhere or copy-pasting from another file without subsequent cleanups.  Unused code is confusing and also adds (unnecessary) runtime overheads.  It's better to remove or comment out this code, and I've used my best judgement to choose between these two options. Perhaps this PR can be improved in this respect (e.g. by removing some code that this first attempt just comments out).

While at it, the PR also fixes some small copy-paste errors (e.g. not checking a test, but repeating a prior test), removes some lines and does some cosmetic cleanups in methods and files which were touched.