### PR TITLE
Improve test times for dt algs

### DIFF
--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -8,4 +8,4 @@ jobs:
     - uses: codespell-project/actions-codespell@master
       with:
         path: src
-        ignore_words_list: iput,ot,testng,toWord,prepending
+        ignore_words_list: iput,ot,testng,toword

--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -8,4 +8,4 @@ jobs:
     - uses: codespell-project/actions-codespell@master
       with:
         path: src
-        ignore_words_list: iput,ot,testng
+        ignore_words_list: iput,ot,testng,toWord,prepending

--- a/src/main/java/de/learnlib/ralib/learning/ralambda/RaDT.java
+++ b/src/main/java/de/learnlib/ralib/learning/ralambda/RaDT.java
@@ -70,13 +70,15 @@ public class RaDT implements RaLearningAlgorithm {
 
 	@Override
 	public void learn() {
-    	if (hyp == null)
-    		buildHypothesis();
+        if (hyp == null) {
+            buildHypothesis();
+        }
 
         while (analyzeCounterExample());
 
-        if (queryStats != null)
+        if (queryStats != null) {
         	queryStats.hypothesisConstructed();
+        }
 	}
 
     private boolean analyzeCounterExample() {
@@ -103,8 +105,9 @@ public class RaDT implements RaLearningAlgorithm {
             return false;
         }
 
-        if (queryStats != null)
+        if (queryStats != null) {
         	queryStats.analyzingCounterExample();
+        }
 
         CEAnalysisResult res = analysis.analyzeCounterexample(ce.getInput());
 
@@ -131,15 +134,16 @@ public class RaDT implements RaLearningAlgorithm {
         Map<Word<PSymbolInstance>, LocationComponent> components = new LinkedHashMap<Word<PSymbolInstance>, LocationComponent>();
         components.putAll(dt.getComponents());
         AutomatonBuilder ab;
-        if (ioMode)
-            ab = new IOAutomatonBuilder(components, consts, dt);
-        else
-            ab = new AutomatonBuilder(components, consts, this.dt);
+        if (ioMode) {
+            ab = new IOAutomatonBuilder(components, consts);
+        } else {
+            ab = new AutomatonBuilder(components, consts);
+        }
         return ab.toRegisterAutomaton();
 	}
 
     public DT getDT() {
-        return this.dt;
+        return dt;
     }
 
 	@Override

--- a/src/main/java/de/learnlib/ralib/learning/ralambda/RaLambda.java
+++ b/src/main/java/de/learnlib/ralib/learning/ralambda/RaLambda.java
@@ -119,8 +119,9 @@ public class RaLambda implements RaLearningAlgorithm {
 
     public void learn() {
 
-    	if (hyp == null)
-    		buildNewHypothesis();
+        if (hyp == null) {
+            buildNewHypothesis();
+        }
 
         while (analyzeCounterExample());
 
@@ -133,8 +134,8 @@ public class RaLambda implements RaLearningAlgorithm {
 
         Map<Word<PSymbolInstance>, LocationComponent> components = new LinkedHashMap<Word<PSymbolInstance>, LocationComponent>();
         components.putAll(dt.getComponents());
-
         AutomatonBuilder ab = new AutomatonBuilder(components, consts, dt);
+
         hyp = (DTHyp) ab.toRegisterAutomaton();
         if (prefixFinder != null) {
         	prefixFinder.setHypothesis(hyp);
@@ -228,8 +229,9 @@ public class RaLambda implements RaLearningAlgorithm {
         	}
         }
 
-        if (noShortPrefixes() && !dt.isMissingParameter())
+        if (noShortPrefixes() && !dt.isMissingParameter()) {
         	buildNewHypothesis();
+        }
 
         return true;
     }
@@ -494,15 +496,20 @@ public class RaLambda implements RaLearningAlgorithm {
         Map<Word<PSymbolInstance>, LocationComponent> components = new LinkedHashMap<Word<PSymbolInstance>, LocationComponent>();
         components.putAll(dt.getComponents());
         AutomatonBuilder ab;
-        if (ioMode)
-            ab = new IOAutomatonBuilder(components, consts, dt);
-        else
-            ab = new AutomatonBuilder(components, consts, this.dt);
+        if (ioMode) {
+            ab = new IOAutomatonBuilder(components, consts);
+        } else {
+            ab = new AutomatonBuilder(components, consts);
+        }
         return ab.toRegisterAutomaton();
     }
 
     public DT getDT() {
-        return this.dt;
+        return dt;
+    }
+
+    public DTHyp getDTHyp() {
+        return hyp;
     }
 
     public Map<Word<PSymbolInstance>, LocationComponent> getComponents() {
@@ -528,6 +535,6 @@ public class RaLambda implements RaLearningAlgorithm {
 
     @Override
     public String toString() {
-        return this.dt.toString();
+        return dt.toString();
     }
 }

--- a/src/test/java/de/learnlib/ralib/ceanalysis/PrefixFinderTest.java
+++ b/src/test/java/de/learnlib/ralib/ceanalysis/PrefixFinderTest.java
@@ -125,7 +125,7 @@ public class PrefixFinderTest extends RaLibTestSuite {
         		consts, I_PUSH, I_POP);
 
         ralambda.learn();
-        final DTHyp hyp = (DTHyp)ralambda.getHypothesis();
+        final DTHyp hyp = ralambda.getDTHyp();
         logger.log(Level.FINE, "HYP1: {0}", hyp);
         System.out.println(hyp);
 

--- a/src/test/java/de/learnlib/ralib/learning/ralambda/GeneratedHypothesesTest.java
+++ b/src/test/java/de/learnlib/ralib/learning/ralambda/GeneratedHypothesesTest.java
@@ -1,0 +1,69 @@
+package de.learnlib.ralib.learning.ralambda;
+
+import static de.learnlib.ralib.example.stack.StackAutomatonExample.AUTOMATON;
+import static de.learnlib.ralib.example.stack.StackAutomatonExample.I_POP;
+import static de.learnlib.ralib.example.stack.StackAutomatonExample.I_PUSH;
+import static de.learnlib.ralib.example.stack.StackAutomatonExample.T_INT;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import de.learnlib.ralib.RaLibTestSuite;
+import de.learnlib.ralib.automata.RegisterAutomaton;
+import de.learnlib.ralib.data.Constants;
+import de.learnlib.ralib.data.DataType;
+import de.learnlib.ralib.dt.DTHyp;
+import de.learnlib.ralib.learning.Hypothesis;
+import de.learnlib.ralib.learning.Measurements;
+import de.learnlib.ralib.learning.MeasuringOracle;
+import de.learnlib.ralib.oracles.DataWordOracle;
+import de.learnlib.ralib.oracles.SDTLogicOracle;
+import de.learnlib.ralib.oracles.SimulatorOracle;
+import de.learnlib.ralib.oracles.TreeOracleFactory;
+import de.learnlib.ralib.oracles.mto.MultiTheorySDTLogicOracle;
+import de.learnlib.ralib.oracles.mto.MultiTheoryTreeOracle;
+import de.learnlib.ralib.solver.ConstraintSolver;
+import de.learnlib.ralib.solver.simple.SimpleConstraintSolver;
+import de.learnlib.ralib.theory.Theory;
+import de.learnlib.ralib.tools.theories.IntegerEqualityTheory;
+
+public class GeneratedHypothesesTest extends RaLibTestSuite {
+
+    /**
+     * Tests that {@link RaLambda#getHypothesis()} returns a generic {@link Hypothesis} (and not a specialized Hypothesis, such as a {@link DTHyp}, which is a lot slower)
+     */
+    @Test
+    public void getHypothesisTest() {
+        Constants consts = new Constants();
+        RegisterAutomaton sul = AUTOMATON;
+        DataWordOracle dwOracle = new SimulatorOracle(sul);
+        ConstraintSolver solver = new SimpleConstraintSolver();
+
+        final Map<DataType, Theory> teachers = new LinkedHashMap<>();
+        IntegerEqualityTheory theory = new IntegerEqualityTheory(T_INT);
+        theory.setUseSuffixOpt(false);
+        teachers.put(T_INT, theory);
+
+        Measurements mes = new Measurements();
+
+        MeasuringOracle mto = new MeasuringOracle(new MultiTheoryTreeOracle(
+              dwOracle, teachers, new Constants(), solver), mes);
+
+        SDTLogicOracle slo = new MultiTheorySDTLogicOracle(consts, solver);
+
+        TreeOracleFactory hypFactory = (RegisterAutomaton hyp) ->
+                new MultiTheoryTreeOracle(new SimulatorOracle(hyp), teachers,
+                        new Constants(), solver);
+
+        RaLambda ralambda = new RaLambda(mto, hypFactory, slo, consts, false, false, I_PUSH, I_POP);
+        ralambda.setSolver(solver);
+
+        ralambda.learn();
+        RegisterAutomaton hyp = ralambda.getHypothesis();
+
+        Assert.assertEquals(hyp.getClass(), Hypothesis.class);
+    }
+}

--- a/src/test/java/de/learnlib/ralib/learning/ralambda/TestSymmetry.java
+++ b/src/test/java/de/learnlib/ralib/learning/ralambda/TestSymmetry.java
@@ -105,7 +105,7 @@ public class TestSymmetry extends RaLibTestSuite {
 
 		System.out.println(learner.getHypothesis().toString());
 		System.out.println(learner.getDT());
-		Assert.assertTrue(hyp.accepts(ce));
+		Assert.assertTrue(learner.getDTHyp().accepts(ce));
 	}
 
 	private RegisterAutomaton buildCT2() {

--- a/src/test/java/de/learnlib/ralib/oracles/mto/OptimizedSymbolicSuffixBuilderTest.java
+++ b/src/test/java/de/learnlib/ralib/oracles/mto/OptimizedSymbolicSuffixBuilderTest.java
@@ -245,7 +245,7 @@ public class OptimizedSymbolicSuffixBuilderTest {
     }
 
     /*
-     * Checks for equality optimized suffixes built by pre-pending using an SDT against those built from concrete prefix/suffix
+     * Checks for equality optimized suffixes built by prepending using an SDT against those built from concrete prefix/suffix
      */
     private void equalsSuffixesFromConcretePrefixSuffix(Word<PSymbolInstance> word, MultiTheoryTreeOracle mto, Constants consts, ConstraintSolver solver) {
         OptimizedSymbolicSuffixBuilder builder = new OptimizedSymbolicSuffixBuilder(consts);


### PR DESCRIPTION
Now RaLambda::getHypothesis returns a regular hyp instead of a DTHyp (which accepts data word by doing expensive operations on the DT). For users wanting a DTHyp instance, there is RaLambda::getDTHyp(). I updated the test cases which required a DTHyp to pass. 

TestSymmetry needs to be looked at, since I had to use DTHyp there, when I am sure it should not have been necessary.  This suggests a bug in the unit test or our handling of symmetries. This can be looked at in a separate issue.