### PR TITLE
Add check to make sure all output suffixes are present for all input words

### DIFF
--- a/src/main/java/de/learnlib/ralib/learning/ralambda/RaDT.java
+++ b/src/main/java/de/learnlib/ralib/learning/ralambda/RaDT.java
@@ -119,7 +119,9 @@ public class RaDT implements RaLearningAlgorithm {
         Word<PSymbolInstance> accSeq = hyp.transformAccessSequence(res.getPrefix());
         DTLeaf leaf = dt.getLeaf(accSeq);
         dt.addSuffix(res.getSuffix(), leaf);
+        while(!dt.checkIOSuffixes());
         while(!dt.checkVariableConsistency(null));
+        buildHypothesis();
         return true;
     }
 

--- a/src/main/java/de/learnlib/ralib/learning/ralambda/RaLambda.java
+++ b/src/main/java/de/learnlib/ralib/learning/ralambda/RaLambda.java
@@ -208,6 +208,8 @@ public class RaLambda implements RaLearningAlgorithm {
         	expand(transition);
         }
 
+        while (!dt.checkIOSuffixes());
+
         boolean consistent = false;
         while (!consistent) {
         	consistent = true;

--- a/src/test/java/de/learnlib/ralib/learning/ralambda/TestOutputSuffixes.java
+++ b/src/test/java/de/learnlib/ralib/learning/ralambda/TestOutputSuffixes.java
@@ -1,0 +1,109 @@
+package de.learnlib.ralib.learning.ralambda;
+
+import java.util.Deque;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import com.google.common.collect.Sets;
+
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import de.learnlib.api.query.DefaultQuery;
+import de.learnlib.ralib.RaLibTestSuite;
+import de.learnlib.ralib.TestUtil;
+import de.learnlib.ralib.automata.RegisterAutomaton;
+import de.learnlib.ralib.automata.xml.RegisterAutomatonImporter;
+import de.learnlib.ralib.data.Constants;
+import de.learnlib.ralib.data.DataType;
+import de.learnlib.ralib.learning.SymbolicSuffix;
+import de.learnlib.ralib.oracles.SimulatorOracle;
+import de.learnlib.ralib.oracles.TreeOracleFactory;
+import de.learnlib.ralib.oracles.io.IOCache;
+import de.learnlib.ralib.oracles.io.IOFilter;
+import de.learnlib.ralib.oracles.io.IOOracle;
+import de.learnlib.ralib.oracles.mto.MultiTheorySDTLogicOracle;
+import de.learnlib.ralib.oracles.mto.MultiTheoryTreeOracle;
+import de.learnlib.ralib.solver.ConstraintSolver;
+import de.learnlib.ralib.solver.simple.SimpleConstraintSolver;
+import de.learnlib.ralib.sul.DataWordSUL;
+import de.learnlib.ralib.sul.SULOracle;
+import de.learnlib.ralib.sul.SimulatorSUL;
+import de.learnlib.ralib.theory.Theory;
+import de.learnlib.ralib.tools.theories.IntegerEqualityTheory;
+import de.learnlib.ralib.words.PSymbolInstance;
+import de.learnlib.ralib.words.ParameterizedSymbol;
+import net.automatalib.words.Word;
+
+public class TestOutputSuffixes extends RaLibTestSuite {
+
+	@Test
+	public void testSIPOutputSuffixesPresent() {
+
+        RegisterAutomatonImporter loader = TestUtil.getLoader(
+                "/de/learnlib/ralib/automata/xml/sip.xml");
+
+        RegisterAutomaton model = loader.getRegisterAutomaton();
+
+        ParameterizedSymbol[] inputs = loader.getInputs().toArray(
+                new ParameterizedSymbol[]{});
+
+        ParameterizedSymbol[] actions = loader.getActions().toArray(
+                new ParameterizedSymbol[]{});
+
+        final Constants consts = loader.getConstants();
+
+
+        final Map<DataType, Theory> teachers = new LinkedHashMap<>();
+        loader.getDataTypes().stream().forEach((t) -> {
+            IntegerEqualityTheory theory = new IntegerEqualityTheory(t);
+            theory.setUseSuffixOpt(true);
+            teachers.put(t, theory);
+        });
+
+        DataWordSUL sul = new SimulatorSUL(model, teachers, consts);
+        IOOracle ioOracle = new SULOracle(sul, ERROR);
+        IOCache ioCache = new IOCache(ioOracle);
+        IOFilter ioFilter = new IOFilter(ioCache, inputs);
+
+        ConstraintSolver solver = new SimpleConstraintSolver();
+
+        MultiTheoryTreeOracle mto = new MultiTheoryTreeOracle(
+                ioFilter, teachers, consts, solver);
+        MultiTheorySDTLogicOracle mlo =
+                new MultiTheorySDTLogicOracle(consts, solver);
+
+        TreeOracleFactory hypFactory = (RegisterAutomaton hyp) ->
+                new MultiTheoryTreeOracle(new SimulatorOracle(hyp), teachers, consts, solver);
+
+        RaDT radt = new RaDT(mto, hypFactory, mlo, consts, true, actions);
+        radt.learn();
+
+        String ces[] = {"IINVITE[1[int]] O100[1[int]] / true",
+        		"IINVITE[0[int]] O100[0[int]] IPRACK[0[int]] O200[0[int]] / true"};
+
+        Deque<DefaultQuery<PSymbolInstance, Boolean>> ceQueue = TestUnknownMemorable.buildSIPCEs(ces, actions);
+
+        while (!ceQueue.isEmpty()) {
+        	radt.addCounterexample(ceQueue.pop());
+        	radt.learn();
+        }
+
+        Set<ParameterizedSymbol> outputs = Sets.difference(Set.of(actions), Set.of(inputs));
+
+        String wordStr[] = {"IINVITE[0[int]] O100[0[int]] IPRACK[0[int]] / true"};
+        ceQueue = TestUnknownMemorable.buildSIPCEs(wordStr, actions);
+        Word<PSymbolInstance> word = ceQueue.getFirst().getInput();
+
+        Set<SymbolicSuffix> suffixes = radt.getDT().getLeaf(word).getPrefix(word).getTQRs().keySet();
+        Set<ParameterizedSymbol> suffixActions = suffixes.stream()
+        		                                         .filter(s -> s.length() == 1)
+        		                                         .map(s -> s.getActions().firstSymbol())
+        		                                         .collect(Collectors.toSet());
+        for (ParameterizedSymbol ps : outputs) {
+        	Assert.assertTrue(suffixActions.contains(ps));
+        }
+	}
+}

--- a/src/test/java/de/learnlib/ralib/learning/ralambda/TestUnknownMemorable.java
+++ b/src/test/java/de/learnlib/ralib/learning/ralambda/TestUnknownMemorable.java
@@ -361,7 +361,7 @@ public class TestUnknownMemorable extends RaLibTestSuite {
         Assert.assertTrue(true);
 	}
 
-	private Deque<DefaultQuery<PSymbolInstance, Boolean>> buildSIPCEs(String[] ceStrings, ParameterizedSymbol[] actionSymbols) {
+	public static Deque<DefaultQuery<PSymbolInstance, Boolean>> buildSIPCEs(String[] ceStrings, ParameterizedSymbol[] actionSymbols) {
 		Deque<DefaultQuery<PSymbolInstance, Boolean>> ces = new LinkedList<>();
 
 		for (String ceString : ceStrings) {
@@ -400,7 +400,7 @@ public class TestUnknownMemorable extends RaLibTestSuite {
 		return ces;
 	}
 
-	private DefaultQuery<PSymbolInstance, Boolean> buildSIPCounterExample(String[] actions, int[] dv, boolean outcome, ParameterizedSymbol[] actionSymbols) {
+	private static DefaultQuery<PSymbolInstance, Boolean> buildSIPCounterExample(String[] actions, int[] dv, boolean outcome, ParameterizedSymbol[] actionSymbols) {
 		Word<PSymbolInstance> ce = Word.epsilon();
 		for (int i = 0; i < actions.length; i++) {
 			String action = actions[i];
@@ -416,7 +416,7 @@ public class TestUnknownMemorable extends RaLibTestSuite {
 		return new DefaultQuery<PSymbolInstance, Boolean>(ce, outcome);
 	}
 
-	private int findMatchingSymbol(String action, ParameterizedSymbol[] actionSymbols) {
+	private static int findMatchingSymbol(String action, ParameterizedSymbol[] actionSymbols) {
 		for (int i = 0; i < actionSymbols.length; i++ ) {
 			if (actionSymbols[i].getName().contains(action))
 				return i;


### PR DESCRIPTION
This applies a check when learning IO systems to ensure that all input words have the necessary output suffixes in the DT. This fix applies to both SLDT and SLLambda.