### PR TITLE
Fix a bug where a suffix parameter could be optimized for equality with a free parameter

### DIFF
--- a/src/main/java/de/learnlib/ralib/oracles/mto/OptimizedSymbolicSuffixBuilder.java
+++ b/src/main/java/de/learnlib/ralib/oracles/mto/OptimizedSymbolicSuffixBuilder.java
@@ -435,7 +435,7 @@ public class OptimizedSymbolicSuffixBuilder {
             if (notSeen || free) {
                 sv = sgen.next(type);
                 if (free) {
-                	freeValues.add(sv);
+                    freeValues.add(sv);
                 }
             }
             seenVals1.add(sv1);

--- a/src/main/java/de/learnlib/ralib/oracles/mto/OptimizedSymbolicSuffixBuilder.java
+++ b/src/main/java/de/learnlib/ralib/oracles/mto/OptimizedSymbolicSuffixBuilder.java
@@ -421,15 +421,21 @@ public class OptimizedSymbolicSuffixBuilder {
 
             // TODO Do we need to make sv free if one of the sv's is equal to a previous sv?
             boolean free = freeIndices1.contains(index1) || freeIndices2.contains(index1) || freeIndices1.contains(index2) || freeIndices2.contains(index2);
+            boolean notSeen = false;
 
             if (seenVals1.contains(sv1) && !free) {
                 sv = sValMapping.get(sv1);
             } else if (seenVals2.contains(sv2) && !free) {
                 sv = sValMapping.get(sv2);
             } else {
+            	notSeen = true;
+            }
+            if (sv != null && freeValues.contains(sv))
+            	free = true;
+            if (notSeen || free) {
                 sv = sgen.next(type);
                 if (free) {
-                    freeValues.add(sv);
+                	freeValues.add(sv);
                 }
             }
             seenVals1.add(sv1);

--- a/src/test/java/de/learnlib/ralib/oracles/mto/OptimizedSymbolicSuffixBuilderTest.java
+++ b/src/test/java/de/learnlib/ralib/oracles/mto/OptimizedSymbolicSuffixBuilderTest.java
@@ -449,4 +449,41 @@ public class OptimizedSymbolicSuffixBuilderTest {
         SymbolicSuffix suffix34 = builder.distinguishingSuffixFromSDTs(prefix3, sdt3, piv3, prefix4, sdt4, piv4,  Word.fromSymbols(a, a, a), new SimpleConstraintSolver());
         Assert.assertEquals(suffix34.toString(), "[s2]((a[s1] a[s2] a[s3] a[s3]))");
     }
+
+    @Test
+    public void testCoalesce() {
+        DataType type = new DataType("int",Integer.class);
+        InputSymbol a = new InputSymbol("a", type);
+
+        DataValue dv1 = new DataValue(type, 0);
+        DataValue dv2 = new DataValue(type, 1);
+        DataValue dv3 = new DataValue(type, 2);
+
+        Constants consts = new Constants();
+        OptimizedSymbolicSuffixBuilder builder = new OptimizedSymbolicSuffixBuilder(consts);
+
+        Word<PSymbolInstance> word1 = Word.fromSymbols(
+        		new PSymbolInstance(a, dv1),
+        		new PSymbolInstance(a, dv1),
+        		new PSymbolInstance(a, dv2),
+        		new PSymbolInstance(a, dv2),
+        		new PSymbolInstance(a, dv3));
+        Word<PSymbolInstance> word2 = Word.fromSymbols(
+        		new PSymbolInstance(a, dv1),
+        		new PSymbolInstance(a, dv2),
+        		new PSymbolInstance(a, dv2),
+        		new PSymbolInstance(a, dv3),
+        		new PSymbolInstance(a, dv3));
+        Word<PSymbolInstance> word3 = Word.fromSymbols(
+        		new PSymbolInstance(a, dv1),
+        		new PSymbolInstance(a, dv1),
+        		new PSymbolInstance(a, dv1),
+        		new PSymbolInstance(a, dv1),
+        		new PSymbolInstance(a, dv1));
+        SymbolicSuffix suffix1 = new SymbolicSuffix(word1.prefix(1), word1.suffix(4));
+        SymbolicSuffix suffix2 = new SymbolicSuffix(word2.prefix(1), word2.suffix(4));
+        SymbolicSuffix suffixExpected = new SymbolicSuffix(word3.prefix(1), word3.suffix(4));
+        SymbolicSuffix suffixActual = builder.coalesceSuffixes(suffix1, suffix2);
+        Assert.assertEquals(suffixExpected, suffixActual);
+    }
 }

--- a/src/test/java/de/learnlib/ralib/oracles/mto/OptimizedSymbolicSuffixBuilderTest.java
+++ b/src/test/java/de/learnlib/ralib/oracles/mto/OptimizedSymbolicSuffixBuilderTest.java
@@ -484,6 +484,6 @@ public class OptimizedSymbolicSuffixBuilderTest {
         SymbolicSuffix suffix2 = new SymbolicSuffix(word2.prefix(1), word2.suffix(4));
         SymbolicSuffix suffixExpected = new SymbolicSuffix(word3.prefix(1), word3.suffix(4));
         SymbolicSuffix suffixActual = builder.coalesceSuffixes(suffix1, suffix2);
-        Assert.assertEquals(suffixExpected, suffixActual);
+        Assert.assertEquals(suffixActual, suffixExpected);
     }
 }


### PR DESCRIPTION
This PR fixes a bug in coalesceSuffixes where a suffix parameter could be optimized for equality with another parameter, even if that parameter is free.