### PR TITLE
Introduce spotbugs checks and fix two bugs classified as High

### DIFF
--- a/.spotbugs/include.xml
+++ b/.spotbugs/include.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FindBugsFilter>
+  <Match>
+    <Bug category="CORRECTNESS,MT_CORRECTNESS,BAD_PRACTICE,PERFORMANCE,STYLE" />
+  </Match>
+</FindBugsFilter>

--- a/pom.xml
+++ b/pom.xml
@@ -86,6 +86,24 @@
                 </executions>
 	    </plugin>
 
+            <!-- Static code analysis -->
+            <plugin>
+                <groupId>com.github.spotbugs</groupId>
+                <artifactId>spotbugs-maven-plugin</artifactId>
+                <version>4.8.3.1</version>
+                <configuration>
+                    <threshold>High</threshold>
+                    <includeFilterFile>.spotbugs/include.xml</includeFilterFile>
+                </configuration>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+
             <!-- Make a jar archive -->
             <plugin>
                 <artifactId>maven-assembly-plugin</artifactId>

--- a/src/main/java/de/learnlib/ralib/solver/simple/Constraint.java
+++ b/src/main/java/de/learnlib/ralib/solver/simple/Constraint.java
@@ -27,7 +27,7 @@ import java.util.Set;
 public abstract class Constraint {
 
 	public static final Monomial TRUE = Monomial.create(Collections.<IntPair>emptyList(), Collections.<IntPair>emptyList());
-	public static final Constraint FALSE = Polynomial.fromSet(Collections.<Monomial>emptySet());
+	public static final Polynomial FALSE = new Polynomial(Collections.<Monomial>emptySet());
 
 	public static Constraint disjunction(List<? extends Constraint> constraints) {
 		Set<Monomial> cset = new HashSet<Monomial>();

--- a/src/main/java/de/learnlib/ralib/solver/simple/Constraint.java
+++ b/src/main/java/de/learnlib/ralib/solver/simple/Constraint.java
@@ -27,7 +27,7 @@ import java.util.Set;
 public abstract class Constraint {
 
 	public static final Monomial TRUE = Monomial.create(Collections.<IntPair>emptyList(), Collections.<IntPair>emptyList());
-	public static final Polynomial FALSE = new Polynomial(Collections.<Monomial>emptySet());
+	public static final Constraint FALSE = Polynomial.fromSet(Collections.<Monomial>emptySet());
 
 	public static Constraint disjunction(List<? extends Constraint> constraints) {
 		Set<Monomial> cset = new HashSet<Monomial>();

--- a/src/main/java/de/learnlib/ralib/solver/simple/Constraint.java
+++ b/src/main/java/de/learnlib/ralib/solver/simple/Constraint.java
@@ -26,8 +26,8 @@ import java.util.Set;
 
 public abstract class Constraint {
 
-	public static final Constraint TRUE = new Monomial(Collections.<IntPair>emptyList(), Collections.<IntPair>emptyList());
-	public static final Constraint FALSE = new Polynomial(Collections.<Monomial>emptySet());
+	public static final Monomial TRUE = Monomial.create(Collections.<IntPair>emptyList(), Collections.<IntPair>emptyList());
+	public static final Polynomial FALSE = new Polynomial(Collections.<Monomial>emptySet());
 
 	public static Constraint disjunction(List<? extends Constraint> constraints) {
 		Set<Monomial> cset = new HashSet<Monomial>();
@@ -62,7 +62,7 @@ public abstract class Constraint {
 	}
 
 	private static void makeConjunction(Set<Monomial> constraints, List<? extends Constraint> csetList) {
-		makeConjunction(constraints, csetList, (Monomial)TRUE, 0);
+		makeConjunction(constraints, csetList, TRUE, 0);
 	}
 
 	private static void makeConjunction(Set<Monomial> constraints, List<? extends Constraint> csetList, Monomial curr, int idx) {

--- a/src/main/java/de/learnlib/ralib/solver/simple/Constraint.java
+++ b/src/main/java/de/learnlib/ralib/solver/simple/Constraint.java
@@ -26,8 +26,8 @@ import java.util.Set;
 
 public abstract class Constraint {
 
-	public static final Constraint TRUE = Monomial.TRUE;
-	public static final Constraint FALSE = Polynomial.FALSE;
+	public static final Constraint TRUE = new Monomial(Collections.<IntPair>emptyList(), Collections.<IntPair>emptyList());
+	public static final Constraint FALSE = new Polynomial(Collections.<Monomial>emptySet());
 
 	public static Constraint disjunction(List<? extends Constraint> constraints) {
 		Set<Monomial> cset = new HashSet<Monomial>();
@@ -62,7 +62,7 @@ public abstract class Constraint {
 	}
 
 	private static void makeConjunction(Set<Monomial> constraints, List<? extends Constraint> csetList) {
-		makeConjunction(constraints, csetList, Monomial.TRUE, 0);
+		makeConjunction(constraints, csetList, (Monomial)TRUE, 0);
 	}
 
 	private static void makeConjunction(Set<Monomial> constraints, List<? extends Constraint> csetList, Monomial curr, int idx) {

--- a/src/main/java/de/learnlib/ralib/solver/simple/Monomial.java
+++ b/src/main/java/de/learnlib/ralib/solver/simple/Monomial.java
@@ -153,10 +153,6 @@ public class Monomial extends Constraint {
 
 	}*/
 
-
-	/* (non-Javadoc)
-	 * @see se.uu.it.synthesis.misc.Const#restrict(int)
-	 */
 	@Override
 	public Monomial restrict(int newDomSize) {
 		List<IntPair> eqs = new ArrayList<IntPair>();
@@ -173,10 +169,6 @@ public class Monomial extends Constraint {
 		return new Monomial(eqs, neqs);
 	}
 
-
-	/* (non-Javadoc)
-	 * @see se.uu.it.synthesis.misc.Const#negate()
-	 */
 	@Override
 	public Constraint negate() {
 		if(isTrue())
@@ -197,18 +189,12 @@ public class Monomial extends Constraint {
 		return result;
 	}
 
-
-
-	/* (non-Javadoc)
-	 * @see se.uu.it.synthesis.misc.Const#print(java.lang.Appendable, java.lang.String[])
-	 */
 	@Override
 	public void print(Appendable a, String[] varNames) throws IOException {
 		if(equalities.isEmpty() && inequalities.isEmpty()) {
 			a.append("true");
 			return;
 		}
-
 
 		boolean first = true;
 		for(IntPair eq : equalities) {
@@ -250,9 +236,6 @@ public class Monomial extends Constraint {
 		a.append(Integer.toString(index+1));
 	}
 
-	/* (non-Javadoc)
-	 * @see se.uu.it.synthesis.misc.Const#shift(int[], int)
-	 */
 	@Override
 	public Monomial shift(int[] numVars, int thisIdx) {
 		int base = 0;
@@ -275,9 +258,6 @@ public class Monomial extends Constraint {
 		return new Monomial(eqs, neqs);
 	}
 
-	/* (non-Javadoc)
-	 * @see se.uu.it.synthesis.misc.Const#shift(int, int, int)
-	 */
 	@Override
 	public Monomial shift(int myVars, int base, int total) {
 		List<IntPair> eqs = new ArrayList<IntPair>(equalities.size());
@@ -290,9 +270,6 @@ public class Monomial extends Constraint {
 		return new Monomial(eqs, neqs);
 	}
 
-	/* (non-Javadoc)
-	 * @see se.uu.it.synthesis.misc.Const#substitute(int[])
-	 */
 	@Override
 	public Monomial substitute(int[] subst) {
 		List<IntPair> eqs = new ArrayList<IntPair>(equalities.size());
@@ -305,10 +282,6 @@ public class Monomial extends Constraint {
 		return Monomial.create(eqs, neqs);
 	}
 
-
-	/* (non-Javadoc)
-	 * @see se.uu.it.synthesis.misc.Const#shift(int)
-	 */
 	@Override
 	public Monomial shift(int shift) {
 		List<IntPair> eqs = new ArrayList<IntPair>(equalities.size());

--- a/src/main/java/de/learnlib/ralib/solver/simple/Monomial.java
+++ b/src/main/java/de/learnlib/ralib/solver/simple/Monomial.java
@@ -27,10 +27,6 @@ import java.util.Set;
 
 public class Monomial extends Constraint {
 
-
-	public static final Monomial TRUE
-		= new Monomial(Collections.<IntPair>emptyList(), Collections.<IntPair>emptyList());
-
 	private static List<IntPair> aggregateEqualities(List<Monomial> constraints) {
 		List<IntPair> result = new ArrayList<IntPair>();
 		for(Monomial c : constraints)
@@ -58,7 +54,6 @@ public class Monomial extends Constraint {
 		return new IntPair(fst, snd);
 	}
 
-
 	public static Monomial conjoin(Monomial ...constraints) {
 		return conjoin(Arrays.asList(constraints));
 	}
@@ -68,7 +63,6 @@ public class Monomial extends Constraint {
 		List<IntPair> neqs = aggregateInequalities(constraints);
 		return create(eqs, neqs);
 	}
-
 
 	public static Monomial create(List<IntPair> equalities, List<IntPair> inequalities) {
 		DisjointSet<Integer> ds = new DisjointSet<Integer>();
@@ -90,7 +84,6 @@ public class Monomial extends Constraint {
 			}
 		}
 
-
 		int pos = 0;
 
 		if(ineqs.length > 0) {
@@ -111,7 +104,6 @@ public class Monomial extends Constraint {
 
 		List<IntPair> eqs = new ArrayList<IntPair>();
 
-
 		for(List<Integer> set : ds.partition()) {
 			if(set.size() < 2)
 				continue;
@@ -129,18 +121,13 @@ public class Monomial extends Constraint {
 		return new Monomial(eqs, (pos <= 0) ? Collections.<IntPair>emptyList() : Arrays.asList(ineqs).subList(0, pos));
 	}
 
-
-
 	private final List<IntPair> equalities;
 	private final List<IntPair> inequalities;
 
-
-
-	private Monomial(List<IntPair> equalities, List<IntPair> inequalities) {
+	Monomial(List<IntPair> equalities, List<IntPair> inequalities) {
 		this.equalities = equalities;
 		this.inequalities = inequalities;
 	}
-
 
 	public List<IntPair> getEqualities() {
 		return equalities;

--- a/src/main/java/de/learnlib/ralib/solver/simple/Monomial.java
+++ b/src/main/java/de/learnlib/ralib/solver/simple/Monomial.java
@@ -124,7 +124,7 @@ public class Monomial extends Constraint {
 	private final List<IntPair> equalities;
 	private final List<IntPair> inequalities;
 
-	Monomial(List<IntPair> equalities, List<IntPair> inequalities) {
+	private Monomial(List<IntPair> equalities, List<IntPair> inequalities) {
 		this.equalities = equalities;
 		this.inequalities = inequalities;
 	}

--- a/src/main/java/de/learnlib/ralib/solver/simple/Polynomial.java
+++ b/src/main/java/de/learnlib/ralib/solver/simple/Polynomial.java
@@ -30,15 +30,15 @@ public class Polynomial extends Constraint {
 	static Constraint fromSet(Set<Monomial> constraints) {
 		int size = constraints.size();
 		if(size == 0)
-			return FALSE;
+		    return new Polynomial(constraints);
 		else if(size == 1)
-			return constraints.iterator().next();
+		    return constraints.iterator().next();
 		return new Polynomial(constraints);
 	}
 
 	private final Set<Monomial> constraints;
 
-	Polynomial(Set<Monomial> constraints) {
+	private Polynomial(Set<Monomial> constraints) {
 		this.constraints = constraints;
 	}
 

--- a/src/main/java/de/learnlib/ralib/solver/simple/Polynomial.java
+++ b/src/main/java/de/learnlib/ralib/solver/simple/Polynomial.java
@@ -27,8 +27,6 @@ import java.util.Set;
 
 public class Polynomial extends Constraint {
 
-	public static final Polynomial FALSE = new Polynomial(Collections.<Monomial>emptySet());
-
 	static Constraint fromSet(Set<Monomial> constraints) {
 		int size = constraints.size();
 		if(size == 0)
@@ -40,7 +38,7 @@ public class Polynomial extends Constraint {
 
 	private final Set<Monomial> constraints;
 
-	private Polynomial(Set<Monomial> constraints) {
+	Polynomial(Set<Monomial> constraints) {
 		this.constraints = constraints;
 	}
 
@@ -174,7 +172,7 @@ public class Polynomial extends Constraint {
 	}
 
 
-	@Override
+        @Override
 	public Constraint normalize() {
 		return negate().negate();
 	}

--- a/src/main/java/de/learnlib/ralib/solver/simple/Polynomial.java
+++ b/src/main/java/de/learnlib/ralib/solver/simple/Polynomial.java
@@ -30,7 +30,7 @@ public class Polynomial extends Constraint {
 	static Constraint fromSet(Set<Monomial> constraints) {
 		int size = constraints.size();
 		if(size == 0)
-		    return new Polynomial(constraints);
+		    return FALSE;
 		else if(size == 1)
 		    return constraints.iterator().next();
 		return new Polynomial(constraints);
@@ -38,7 +38,7 @@ public class Polynomial extends Constraint {
 
 	private final Set<Monomial> constraints;
 
-	private Polynomial(Set<Monomial> constraints) {
+	Polynomial(Set<Monomial> constraints) {
 		this.constraints = constraints;
 	}
 


### PR DESCRIPTION
Enable `spotbugs-maven-plugin` checks (currently restricted to those classified as `High`).
This revealed two uses of subclass accesses during initialization of a class, which were fixed in this PR.