### PR TITLE
Clean up tests to check expected results rather than print them

### DIFF
--- a/src/main/java/de/learnlib/ralib/automata/Assignment.java
+++ b/src/main/java/de/learnlib/ralib/automata/Assignment.java
@@ -45,14 +45,14 @@ public class Assignment {
         for (Entry<Register, ? extends SymbolicDataValue> e : assignment) {
             SymbolicDataValue valp = e.getValue();
             if (valp.isRegister()) {
-                val.put(e.getKey(), registers.get( (Register) valp));
+                val.put(e.getKey(), registers.get((Register) valp));
             }
             else if (valp.isParameter()) {
-                val.put(e.getKey(), parameters.get( (Parameter) valp));
+                val.put(e.getKey(), parameters.get((Parameter) valp));
             }
             //TODO: check if we want to copy constant values into vars
             else if (valp.isConstant()) {
-                val.put(e.getKey(), consts.get( (Constant) valp));
+                val.put(e.getKey(), consts.get((Constant) valp));
             }
             else {
                 throw new IllegalStateException("Illegal assignment: " +

--- a/src/main/java/de/learnlib/ralib/learning/Hypothesis.java
+++ b/src/main/java/de/learnlib/ralib/learning/Hypothesis.java
@@ -93,7 +93,7 @@ implements AccessSequenceTransformer<PSymbolInstance>, TransitionSequenceTransfo
         List<Transition> tseq = getTransitions(word);
         //System.out.println("TSEQ: " + tseq);
         if (tseq == null)
-        	return null;
+	    return null;
         Transition last = tseq.get(tseq.size() -1);
         return transitionSequences.get(last);
     }
@@ -102,25 +102,25 @@ implements AccessSequenceTransformer<PSymbolInstance>, TransitionSequenceTransfo
     	return transformTransitionSequence(word);
     }
 
-	public Word<PSymbolInstance> branchWithSameGuard(Word<PSymbolInstance> word, Branching branching) {
-		ParameterizedSymbol ps = word.lastSymbol().getBaseSymbol();
+    public Word<PSymbolInstance> branchWithSameGuard(Word<PSymbolInstance> word, Branching branching) {
+	ParameterizedSymbol ps = word.lastSymbol().getBaseSymbol();
 
         List<Pair<Transition, VarValuation>> tvseq = getTransitionsAndValuations(word);
         VarValuation vars = tvseq.get(tvseq.size()-1).getSecond();
         ParValuation pval = new ParValuation(word.lastSymbol());
 
-		for (Map.Entry<Word<PSymbolInstance>, TransitionGuard> e : branching.getBranches().entrySet()) {
-			if (e.getKey().lastSymbol().getBaseSymbol().equals(ps)) {
-			    if (e.getValue().isSatisfied(vars, pval, constants)) {
-			        return e.getKey();
-			    }
-			}
+	for (Map.Entry<Word<PSymbolInstance>, TransitionGuard> e : branching.getBranches().entrySet()) {
+	    if (e.getKey().lastSymbol().getBaseSymbol().equals(ps)) {
+		if (e.getValue().isSatisfied(vars, pval, constants)) {
+		    return e.getKey();
 		}
-		return null;
+	    }
 	}
+	return null;
+    }
 
-	public VarMapping<Register, ? extends SymbolicDataValue> getLastTransitionAssignment(Word<PSymbolInstance> word) {
-		List<Transition> tseq = getTransitions(word);
-		return tseq.get(tseq.size() - 1).getAssignment().getAssignment();
-	}
+    public VarMapping<Register, ? extends SymbolicDataValue> getLastTransitionAssignment(Word<PSymbolInstance> word) {
+	List<Transition> tseq = getTransitions(word);
+	return tseq.get(tseq.size() - 1).getAssignment().getAssignment();
+    }
 }

--- a/src/test/java/de/learnlib/ralib/ceanalysis/PrefixFinderTest.java
+++ b/src/test/java/de/learnlib/ralib/ceanalysis/PrefixFinderTest.java
@@ -23,8 +23,8 @@ import static de.learnlib.ralib.example.stack.StackAutomatonExample.T_INT;
 
 import java.util.LinkedHashMap;
 import java.util.Map;
-import java.util.logging.Level;
 
+import org.testng.Assert;
 import org.testng.annotations.Test;
 
 import de.learnlib.ralib.RaLibTestSuite;
@@ -58,7 +58,6 @@ public class PrefixFinderTest extends RaLibTestSuite {
 
     @Test
     public void prefixFinderTest() {
-
         Constants consts = new Constants();
         RegisterAutomaton sul = AUTOMATON;
         DataWordOracle dwOracle = new SimulatorOracle(sul);
@@ -82,8 +81,7 @@ public class PrefixFinderTest extends RaLibTestSuite {
 
         rastar.learn();
         final Hypothesis hyp = rastar.getHypothesis();
-        logger.log(Level.FINE, "HYP1: {0}", hyp);
-        System.out.println(hyp);
+        // System.out.println(hyp);
 
         Word<PSymbolInstance> ce = Word.fromSymbols(
                 new PSymbolInstance(I_REGISTER,
@@ -100,17 +98,17 @@ public class PrefixFinderTest extends RaLibTestSuite {
         );
 
         Word<PSymbolInstance> prefix = pf.analyzeCounterexample(ce).getPrefix();
-        System.out.println(prefix);
+	Assert.assertEquals(prefix.toString(), "register[0[T_uid], 0[T_pwd]]");
     }
 
-	@Test
-	public void prefixFinderMultipleAccessSequencesTest() {
-		Constants consts = new Constants();
-		RegisterAutomaton sul = de.learnlib.ralib.example.stack.StackAutomatonExample.AUTOMATON;
-		DataWordOracle dwOracle = new SimulatorOracle(sul);
+    @Test
+    public void prefixFinderMultipleAccessSequencesTest() {
+	Constants consts = new Constants();
+	RegisterAutomaton sul = de.learnlib.ralib.example.stack.StackAutomatonExample.AUTOMATON;
+	DataWordOracle dwOracle = new SimulatorOracle(sul);
 
-		final Map<DataType, Theory> teachers = new LinkedHashMap<>();
-		teachers.put(T_INT, new IntegerEqualityTheory(T_INT));
+	final Map<DataType, Theory> teachers = new LinkedHashMap<>();
+	teachers.put(T_INT, new IntegerEqualityTheory(T_INT));
 
         ConstraintSolver solver = new SimpleConstraintSolver();
 
@@ -126,8 +124,7 @@ public class PrefixFinderTest extends RaLibTestSuite {
 
         ralambda.learn();
         final DTHyp hyp = ralambda.getDTHyp();
-        logger.log(Level.FINE, "HYP1: {0}", hyp);
-        System.out.println(hyp);
+        // System.out.println(hyp);
 
         Word<PSymbolInstance> shortPrefix = Word.fromSymbols(
         		new PSymbolInstance(I_PUSH, new DataValue(T_INT, 0)));
@@ -148,8 +145,7 @@ public class PrefixFinderTest extends RaLibTestSuite {
         );
 
         Word<PSymbolInstance> prefix = pf.analyzeCounterexample(ce).getPrefix();
-        System.out.println(prefix);
-
-	}
+	Assert.assertEquals(prefix.toString(), "push[0[T_int]] pop[0[T_int]]");
+    }
 
 }

--- a/src/test/java/de/learnlib/ralib/learning/QueryStatisticsTest.java
+++ b/src/test/java/de/learnlib/ralib/learning/QueryStatisticsTest.java
@@ -14,41 +14,39 @@ import net.automatalib.word.Word;
 
 public class QueryStatisticsTest extends RaLibTestSuite {
 
-	public static final InputSymbol A = new InputSymbol("a", new DataType[] {});
+    public static final InputSymbol A = new InputSymbol("a", new DataType[] {});
 
-	@Test
-	public void testCounterexampleStatistics() {
+    @Test
+    public void counterexampleStatisticsTest() {
 
-		DataWordSUL sul = null;
-		QueryStatistics qs = new QueryStatistics(null, sul);
+	DataWordSUL sul = null;
+	QueryStatistics qs = new QueryStatistics(null, sul);
 
-		Word<PSymbolInstance> ceLen6 = buildCE(2);
-		Word<PSymbolInstance> ceLen2 = buildCE(6);
-		Word<PSymbolInstance> ceLen7 = buildCE(7);
+	Word<PSymbolInstance> ceLen6 = buildCE(2);
+	Word<PSymbolInstance> ceLen2 = buildCE(6);
+	Word<PSymbolInstance> ceLen7 = buildCE(7);
 
-		qs.analyzeCE(ceLen2);
-		qs.analyzeCE(ceLen6);
-		qs.analyzeCE(ceLen7);
+	qs.analyzeCE(ceLen2);
+	qs.analyzeCE(ceLen6);
+	qs.analyzeCE(ceLen7);
 
-		Set<Word<PSymbolInstance>> ces = qs.getCEs();
+	Set<Word<PSymbolInstance>> ces = qs.getCEs();
+	Assert.assertEquals(ces.size(), 3);
+	Assert.assertTrue(ces.contains(ceLen2));
+	Assert.assertTrue(ces.contains(ceLen6));
+	Assert.assertTrue(ces.contains(ceLen7));
 
-		Assert.assertEquals(ces.size(), 3);
-		Assert.assertTrue(ces.contains(ceLen2));
-		Assert.assertTrue(ces.contains(ceLen6));
-		Assert.assertTrue(ces.contains(ceLen7));
+	String str = qs.toString();
+	Assert.assertTrue(str.contains("Counterexamples: 3"));
+	Assert.assertTrue(str.contains("CE max length: 7"));
+	Assert.assertTrue(str.contains("CE avg length: 5"));
+    }
 
-		String str = qs.toString();
-
-		Assert.assertTrue(str.contains("Counterexamples: 3"));
-		Assert.assertTrue(str.contains("CE max length: 7"));
-		Assert.assertTrue(str.contains("CE avg length: 5"));
+    private Word<PSymbolInstance> buildCE(int length) {
+	Word<PSymbolInstance> ce = Word.epsilon();
+	for (int i = 0; i < length; i++) {
+	    ce = ce.append(new PSymbolInstance(A));
 	}
-
-	private Word<PSymbolInstance> buildCE(int length) {
-		Word<PSymbolInstance> ce = Word.epsilon();
-		for (int i = 0; i < length; i++) {
-			ce = ce.append(new PSymbolInstance(A));
-		}
-		return ce;
-	}
+	return ce;
+    }
 }

--- a/src/test/java/de/learnlib/ralib/learning/ralambda/LearnLoginTest.java
+++ b/src/test/java/de/learnlib/ralib/learning/ralambda/LearnLoginTest.java
@@ -42,8 +42,7 @@ import net.automatalib.word.Word;
 public class LearnLoginTest extends RaLibTestSuite {
 
     @Test
-    public void learnLoginExample() {
-
+    public void learnLoginTest() {
         Constants consts = new Constants();
         RegisterAutomaton sul = AUTOMATON;
         DataWordOracle dwOracle = new SimulatorOracle(sul);
@@ -86,9 +85,8 @@ public class LearnLoginTest extends RaLibTestSuite {
         Assert.assertEquals(hyp.getTransitions().size(), 11);
     }
 
-
     @Test
-    public void learnLoginExampleRandom() {
+    public void learnLoginRandomTest() {
         final int SEEDS = 10;
 
         Constants consts = new Constants();
@@ -105,22 +103,42 @@ public class LearnLoginTest extends RaLibTestSuite {
 
         RaLibLearningExperimentRunner runner = new RaLibLearningExperimentRunner(logger);
         runner.setMaxDepth(6);
-        for (int seed=0; seed<SEEDS; seed++) {
-        	runner.setSeed(seed);
-	        Hypothesis hyp = runner.run(RaLearningAlgorithmName.RALAMBDA, dwOracle, teachers, consts, solver, new ParameterizedSymbol [] {I_LOGIN, I_LOGOUT, I_REGISTER});
-	        measuresLambda[seed] = runner.getMeasurements();
-	        runner.resetMeasurements();
+        for (int seed = 0; seed < SEEDS; seed++) {
+	    runner.setSeed(seed);
+	    Hypothesis hyp = runner.run(RaLearningAlgorithmName.RALAMBDA, dwOracle, teachers, consts, solver, new ParameterizedSymbol [] {I_LOGIN, I_LOGOUT, I_REGISTER});
+	    measuresLambda[seed] = runner.getMeasurements();
+	    runner.resetMeasurements();
 
-	        Assert.assertEquals(hyp.getStates().size(), 4);
-	        Assert.assertEquals(hyp.getTransitions().size(), 14);
-	        logger.log(Level.FINE, "HYP: {0}", hyp);
+	    Assert.assertEquals(hyp.getStates().size(), 4);
+	    Assert.assertEquals(hyp.getTransitions().size(), 14);
+	    logger.log(Level.FINE, "HYP: {0}", hyp);
 
-	        hyp = runner.run(RaLearningAlgorithmName.RASTAR, dwOracle, teachers, consts, solver, new ParameterizedSymbol [] {I_LOGIN, I_LOGOUT, I_REGISTER});
-	        measuresStar[seed] = runner.getMeasurements();
-	        runner.resetMeasurements();
+	    hyp = runner.run(RaLearningAlgorithmName.RASTAR, dwOracle, teachers, consts, solver, new ParameterizedSymbol [] {I_LOGIN, I_LOGOUT, I_REGISTER});
+	    measuresStar[seed] = runner.getMeasurements();
+	    runner.resetMeasurements();
         }
-        System.out.println("Queries (Lambda): " + Arrays.toString(measuresLambda));
-        System.out.println("Queries (Star): " + Arrays.toString(measuresStar));
+        Assert.assertEquals(Arrays.toString(measuresLambda),
+			    "[{TQ: 64, Resets: 2511, Inputs: 0}," +
+			    " {TQ: 64, Resets: 2485, Inputs: 0}," +
+			    " {TQ: 64, Resets: 1958, Inputs: 0}," +
+			    " {TQ: 64, Resets: 1959, Inputs: 0}," +
+			    " {TQ: 64, Resets: 1886, Inputs: 0}," +
+			    " {TQ: 64, Resets: 2750, Inputs: 0}," +
+			    " {TQ: 64, Resets: 2487, Inputs: 0}," +
+			    " {TQ: 64, Resets: 1737, Inputs: 0}," +
+			    " {TQ: 68, Resets: 1758, Inputs: 0}," +
+			    " {TQ: 64, Resets: 1604, Inputs: 0}]");
+        Assert.assertEquals(Arrays.toString(measuresStar),
+			    "[{TQ: 65, Resets: 2339, Inputs: 0}," +
+			    " {TQ: 65, Resets: 2313, Inputs: 0}," +
+			    " {TQ: 65, Resets: 2208, Inputs: 0}," +
+			    " {TQ: 64, Resets: 2200, Inputs: 0}," +
+			    " {TQ: 65, Resets: 2136, Inputs: 0}," +
+			    " {TQ: 65, Resets: 2578, Inputs: 0}," +
+			    " {TQ: 65, Resets: 2315, Inputs: 0}," +
+			    " {TQ: 65, Resets: 2192, Inputs: 0}," +
+			    " {TQ: 65, Resets: 3618, Inputs: 0}," +
+			    " {TQ: 65, Resets: 2059, Inputs: 0}]");
     }
 
 }

--- a/src/test/java/de/learnlib/ralib/learning/ralambda/LearnPQTest.java
+++ b/src/test/java/de/learnlib/ralib/learning/ralambda/LearnPQTest.java
@@ -70,7 +70,6 @@ public class LearnPQTest extends RaLibTestSuite {
         final Map<DataType, Theory> teachers = new LinkedHashMap<>();
         teachers.put(doubleType, new DoubleInequalityTheory(doubleType));
 
-
         JConstraintsConstraintSolver jsolv = TestUtil.getZ3Solver();
         MultiTheoryTreeOracle mto = new MultiTheoryTreeOracle(
                 dwOracle, teachers, new Constants(), jsolv);
@@ -126,7 +125,7 @@ public class LearnPQTest extends RaLibTestSuite {
 
     @Test
     public void learnPQRandom() {
-        int SEEDS = 1;
+        int SEEDS = 1;	// NB: results are hard-coded for one seed only
         Constants consts = new Constants();
         DataWordOracle dwOracle =
                 new de.learnlib.ralib.example.priority.PriorityQueueOracle(2);
@@ -134,26 +133,25 @@ public class LearnPQTest extends RaLibTestSuite {
         final Map<DataType, Theory> teachers = new LinkedHashMap<>();
         teachers.put(doubleType, new DoubleInequalityTheory(doubleType));
 
-
         JConstraintsConstraintSolver jsolv = TestUtil.getZ3Solver();
         RaLibLearningExperimentRunner runner = new RaLibLearningExperimentRunner(logger);
         runner.setMaxDepth(4);
 //        runner.setUseOldAnalyzer(true);
 
         Measurements[] ralambdaCount = new Measurements [SEEDS];
-//        Measurements[] rastarCount = new Measurements [SEEDS];
-        for (int i=0; i<SEEDS; i++) {
-            System.out.println(i);
+        Measurements[] rastarCount = new Measurements [SEEDS];
+        for (int i = 0; i < SEEDS; i++) {
             runner.setSeed(i);
             runner.run(RaLearningAlgorithmName.RALAMBDA, dwOracle, teachers, consts, jsolv, new ParameterizedSymbol [] {OFFER, POLL});
             ralambdaCount[i] = runner.getMeasurements();
             runner.resetMeasurements();
-//            runner.run(RaLearningAlgorithmName.RASTAR, dwOracle, teachers, consts, jsolv, new ParameterizedSymbol [] {OFFER, POLL});
-//            rastarCount[i] = runner.getMeasurements();
-//            runner.resetMeasurements();
+            runner.run(RaLearningAlgorithmName.RASTAR, dwOracle, teachers, consts, jsolv, new ParameterizedSymbol [] {OFFER, POLL});
+            rastarCount[i] = runner.getMeasurements();
+            runner.resetMeasurements();
         }
 
-        System.out.println("Queries (Lambda): " + Arrays.toString(ralambdaCount));
-//        System.out.println("Queries (Star): " + Arrays.toString(rastarCount));
+	// hard-coded results from first seed
+        Assert.assertEquals(Arrays.toString(ralambdaCount), "[{TQ: 82, Resets: 1989, Inputs: 0}]");
+        Assert.assertEquals(Arrays.toString(rastarCount),   "[{TQ: 71, Resets: 8321, Inputs: 0}]");
     }
 }

--- a/src/test/java/de/learnlib/ralib/learning/ralambda/LearnRepeaterTest.java
+++ b/src/test/java/de/learnlib/ralib/learning/ralambda/LearnRepeaterTest.java
@@ -36,8 +36,9 @@ import de.learnlib.ralib.words.PSymbolInstance;
 import net.automatalib.word.Word;
 
 public class LearnRepeaterTest extends RaLibTestSuite {
-	@Test
-	public void learnRepeater() {
+
+    @Test
+    public void learnRepeaterTest() {
 
         Constants consts = new Constants();
 
@@ -48,24 +49,24 @@ public class LearnRepeaterTest extends RaLibTestSuite {
 
         RepeaterSUL sul = new RepeaterSUL();
         IOOracle ioOracle = new SULOracle(sul, RepeaterSUL.ERROR);
-	    IOCache ioCache = new IOCache(ioOracle);
-	    IOFilter oracle = new IOFilter(ioCache, sul.getInputSymbols());
+	IOCache ioCache = new IOCache(ioOracle);
+	IOFilter oracle = new IOFilter(ioCache, sul.getInputSymbols());
 
         ConstraintSolver solver = new SimpleConstraintSolver();
 
-        MultiTheoryTreeOracle mto = new MultiTheoryTreeOracle(
-                oracle, teachers, consts, solver);
+        MultiTheoryTreeOracle mto =
+	    new MultiTheoryTreeOracle(oracle, teachers, consts, solver);
         MultiTheorySDTLogicOracle mlo =
-                new MultiTheorySDTLogicOracle(consts, solver);
+	    new MultiTheorySDTLogicOracle(consts, solver);
 
         TreeOracleFactory hypFactory = (RegisterAutomaton hyp) ->
-                new MultiTheoryTreeOracle(new SimulatorOracle(hyp), teachers, consts, solver);
+	    new MultiTheoryTreeOracle(new SimulatorOracle(hyp), teachers, consts, solver);
 
         Measurements measurements = new Measurements();
-        QueryStatistics queryStats = new QueryStatistics(measurements, ioOracle);
+        QueryStatistics stats = new QueryStatistics(measurements, ioOracle);
 
         RaLambda learner = new RaLambda(mto, hypFactory, mlo, consts, true, sul.getActionSymbols());
-        learner.setStatisticCounter(queryStats);
+        learner.setStatisticCounter(stats);
         learner.setSolver(solver);
 
         learner.learn();
@@ -75,20 +76,24 @@ public class LearnRepeaterTest extends RaLibTestSuite {
         Assert.assertEquals(repeater.repeat(0), (Integer)0);
         Assert.assertNull(repeater.repeat(0));
 
-        Word<PSymbolInstance> ce = Word.fromSymbols(
-        		new PSymbolInstance(IPUT, new DataValue(TINT, 0)),
-        		new PSymbolInstance(OECHO, new DataValue(TINT, 0)),
-        		new PSymbolInstance(IPUT, new DataValue(TINT, 0)),
-        		new PSymbolInstance(OECHO, new DataValue(TINT, 0)),
-        		new PSymbolInstance(IPUT, new DataValue(TINT, 0)),
-        		new PSymbolInstance(OECHO, new DataValue(TINT, 0)));
+        Word<PSymbolInstance> ce =
+	    Word.fromSymbols(new PSymbolInstance(IPUT, new DataValue(TINT, 0)),
+			     new PSymbolInstance(OECHO, new DataValue(TINT, 0)),
+			     new PSymbolInstance(IPUT, new DataValue(TINT, 0)),
+			     new PSymbolInstance(OECHO, new DataValue(TINT, 0)),
+			     new PSymbolInstance(IPUT, new DataValue(TINT, 0)),
+			     new PSymbolInstance(OECHO, new DataValue(TINT, 0)));
 
         learner.addCounterexample(new DefaultQuery<PSymbolInstance, Boolean>(ce, false));
 
         learner.learn();
 
-        System.out.println(queryStats.toString());
-
-        Assert.assertTrue(true);
-	}
+	String str = stats.toString();
+	Assert.assertTrue(str.contains("Counterexamples: 1"));
+        Assert.assertTrue(str.contains("CE max length: 6"));
+        Assert.assertTrue(str.contains("CE Analysis: {TQ: 0, Resets: 7, Inputs: 0}"));
+        Assert.assertTrue(str.contains("Processing / Refinement: {TQ: 0, Resets: 5, Inputs: 0}"));
+        Assert.assertTrue(str.contains("Other: {TQ: 0, Resets: 1, Inputs: 0}"));
+        Assert.assertTrue(str.contains("Total: {TQ: 0, Resets: 13, Inputs: 0}"));
+    }
 }

--- a/src/test/java/de/learnlib/ralib/learning/ralambda/LearnStackTest.java
+++ b/src/test/java/de/learnlib/ralib/learning/ralambda/LearnStackTest.java
@@ -47,7 +47,7 @@ import net.automatalib.word.Word;
 public class LearnStackTest extends RaLibTestSuite {
 
     @Test
-    public void learnStackExample() {
+    public void learnStackTest() {
 
 	Constants consts = new Constants();
         RegisterAutomaton sul = AUTOMATON;
@@ -102,7 +102,7 @@ public class LearnStackTest extends RaLibTestSuite {
     }
 
     @Test
-    public void learnStackExampleSwitchedCE() {
+    public void learnStackSwitchedCETest() {
         Constants consts = new Constants();
         RegisterAutomaton sul = AUTOMATON;
         DataWordOracle dwOracle = new SimulatorOracle(sul);
@@ -175,7 +175,7 @@ public class LearnStackTest extends RaLibTestSuite {
     }
 
     @Test
-    public void learnStackExampleLongCE() {
+    public void learnStackLongCETest() {
         Constants consts = new Constants();
         RegisterAutomaton sul = AUTOMATON;
         DataWordOracle dwOracle = new SimulatorOracle(sul);
@@ -220,7 +220,7 @@ public class LearnStackTest extends RaLibTestSuite {
     }
 
     @Test
-    public void learnStackExampleRandom() {
+    public void learnStackRandomTest() {
 	final int SEEDS = 10;
 	Constants consts = new Constants();
 	RegisterAutomaton sul = AUTOMATON;
@@ -251,7 +251,27 @@ public class LearnStackTest extends RaLibTestSuite {
             runner.resetMeasurements();
         }
 
-        System.out.println("Queries (RaLambda): " + Arrays.toString(measuresLambda));
-        System.out.println("Queries (RaStar): " + Arrays.toString(measuresStar));
+        Assert.assertEquals(Arrays.toString(measuresLambda),
+			    "[{TQ: 60, Resets: 1199, Inputs: 0}," +
+			    " {TQ: 65, Resets: 1859, Inputs: 0}," +
+			    " {TQ: 60, Resets: 1178, Inputs: 0}," +
+			    " {TQ: 62, Resets: 1516, Inputs: 0}," +
+			    " {TQ: 70, Resets: 2717, Inputs: 0}," +
+			    " {TQ: 62, Resets: 1443, Inputs: 0}," +
+			    " {TQ: 56, Resets: 1148, Inputs: 0}," +
+			    " {TQ: 41, Resets: 1089, Inputs: 0}," +
+			    " {TQ: 78, Resets: 2478, Inputs: 0}," +
+			    " {TQ: 44, Resets: 1139, Inputs: 0}]");
+        Assert.assertEquals(Arrays.toString(measuresStar),
+			    "[{TQ: 51, Resets: 1582, Inputs: 0}," +
+			    " {TQ: 50, Resets: 12577, Inputs: 0}," +
+			    " {TQ: 63, Resets: 1317, Inputs: 0}," +
+			    " {TQ: 50, Resets: 10633, Inputs: 0}," +
+			    " {TQ: 39, Resets: 10917, Inputs: 0}," +
+			    " {TQ: 62, Resets: 1310, Inputs: 0}," +
+			    " {TQ: 60, Resets: 1298, Inputs: 0}," +
+			    " {TQ: 49, Resets: 1207, Inputs: 0}," +
+			    " {TQ: 53, Resets: 11290, Inputs: 0}," +
+			    " {TQ: 49, Resets: 1301, Inputs: 0}]");
     }
 }

--- a/src/test/java/de/learnlib/ralib/learning/ralambda/TestSymmetry.java
+++ b/src/test/java/de/learnlib/ralib/learning/ralambda/TestSymmetry.java
@@ -42,172 +42,167 @@ import net.automatalib.word.Word;
 
 public class TestSymmetry extends RaLibTestSuite {
 
-	private static final DataType T_INT = new DataType("int", Integer.class);
+    private static final DataType T_INT = new DataType("int", Integer.class);
 
-	private static final InputSymbol A =
-			new InputSymbol("a", new DataType[] {T_INT});
-	private static final InputSymbol B =
-			new InputSymbol("b", new DataType[] {T_INT});
+    private static final InputSymbol A = new InputSymbol("a", new DataType[] {T_INT});
+    private static final InputSymbol B = new InputSymbol("b", new DataType[] {T_INT});
 
-	@Test
-	public void learnSymmetryExampleCT2() {
+    @Test
+    public void learnSymmetryExampleCT2() {
+	Constants consts = new Constants();
+	RegisterAutomaton sul = buildCT2();
+	DataWordOracle dwOracle = new SimulatorOracle(sul);
 
-		Constants consts = new Constants();
-		RegisterAutomaton sul = buildCT2();
-		DataWordOracle dwOracle = new SimulatorOracle(sul);
+	final Map<DataType, Theory> teachers = new LinkedHashMap<>();
+	teachers.put(T_INT, new IntegerEqualityTheory(T_INT));
 
-		final Map<DataType, Theory> teachers = new LinkedHashMap<>();
-		teachers.put(T_INT, new IntegerEqualityTheory(T_INT));
+	ConstraintSolver solver = new SimpleConstraintSolver();
 
-		ConstraintSolver solver = new SimpleConstraintSolver();
+	MultiTheoryTreeOracle mto = new MultiTheoryTreeOracle(dwOracle, teachers, new Constants(), solver);
 
-		MultiTheoryTreeOracle mto = new MultiTheoryTreeOracle(dwOracle, teachers, new Constants(), solver);
+	SDTLogicOracle slo = new MultiTheorySDTLogicOracle(consts, solver);
 
-		SDTLogicOracle slo = new MultiTheorySDTLogicOracle(consts, solver);
+	TreeOracleFactory hypFactory = (RegisterAutomaton hyp) ->
+	    new MultiTheoryTreeOracle(new SimulatorOracle(hyp), teachers,
+				      new Constants(), solver);
 
-		TreeOracleFactory hypFactory = (RegisterAutomaton hyp) ->
-				new MultiTheoryTreeOracle(new SimulatorOracle(hyp), teachers,
-						new Constants(), solver);
+	// System.out.println(sul);
+	// System.out.println("---------------------------------");
 
-		System.out.println(sul);
-		System.out.println("---------------------------------");
+	RaLambda learner = new RaLambda(mto, hypFactory, slo, consts, false, false, A, B);
+	learner.setSolver(solver);
+	learner.learn();
 
-		RaLambda learner = new RaLambda(mto, hypFactory, slo, consts, false, false, A, B);
-		learner.setSolver(solver);
+	Word<PSymbolInstance> ce =
+	    Word.fromSymbols(new PSymbolInstance(A, new DataValue(T_INT, 1)),
+			     new PSymbolInstance(A, new DataValue(T_INT, 2)),
+			     new PSymbolInstance(A, new DataValue(T_INT, 1)));
+	learner.addCounterexample(new DefaultQuery<>(ce, true));
+	learner.learn();
 
-		learner.learn();
+	Hypothesis hyp = learner.getHypothesis();
+	// System.out.println(hyp.toString());
+	// System.out.println(learner.getDT());
 
-		Word<PSymbolInstance> ce = Word.fromSymbols(
-				new PSymbolInstance(A, new DataValue(T_INT, 1)),
-				new PSymbolInstance(A, new DataValue(T_INT, 2)),
-				new PSymbolInstance(A, new DataValue(T_INT, 1)));
+	ce = Word.fromSymbols(new PSymbolInstance(A, new DataValue(T_INT, 1)),
+			      new PSymbolInstance(A, new DataValue(T_INT, 2)),
+			      new PSymbolInstance(B, new DataValue(T_INT, 3)),
+			      new PSymbolInstance(B, new DataValue(T_INT, 4)),
+			      new PSymbolInstance(B, new DataValue(T_INT, 2)),
+			      new PSymbolInstance(B, new DataValue(T_INT, 1)));
 
-		learner.addCounterexample(new DefaultQuery<>(ce, true));
-		learner.learn();
+	Assert.assertTrue(sul.accepts(ce));
+	Assert.assertFalse(hyp.accepts(ce));
 
-		Hypothesis hyp = learner.getHypothesis();
-		System.out.println(learner.getHypothesis().toString());
-		System.out.println(learner.getDT());
+	learner.addCounterexample(new DefaultQuery<>(ce, true));
+	learner.learn();
 
-		ce = Word.fromSymbols(
-				new PSymbolInstance(A, new DataValue(T_INT, 1)),
-				new PSymbolInstance(A, new DataValue(T_INT, 2)),
-				new PSymbolInstance(B, new DataValue(T_INT, 3)),
-				new PSymbolInstance(B, new DataValue(T_INT, 4)),
-				new PSymbolInstance(B, new DataValue(T_INT, 2)),
-				new PSymbolInstance(B, new DataValue(T_INT, 1)));
+	// System.out.println(learner.getHypothesis().toString());
+	// System.out.println(learner.getDT());
+	Assert.assertTrue(learner.getDTHyp().accepts(ce));
+    }
 
-		System.out.println(sul.accepts(ce));
-		System.out.println(hyp.accepts(ce));
+    private RegisterAutomaton buildCT2() {
+	MutableRegisterAutomaton ra = new MutableRegisterAutomaton();
 
-		learner.addCounterexample(new DefaultQuery<>(ce, true));
-		learner.learn();
+	RALocation l_eps = ra.addInitialState(false);
+	RALocation l_a = ra.addState(false);
+	RALocation l_aa = ra.addState(false);
+	RALocation l_aab = ra.addState(false);
+	RALocation l_aabb = ra.addState(false);
+	RALocation l_aabbb = ra.addState(false);
 
-		System.out.println(learner.getHypothesis().toString());
-		System.out.println(learner.getDT());
-		Assert.assertTrue(learner.getDTHyp().accepts(ce));
-	}
+	RALocation l_sink = ra.addState(false);
+	RALocation l_final = ra.addState(true);
 
-	private RegisterAutomaton buildCT2() {
-		MutableRegisterAutomaton ra = new MutableRegisterAutomaton();
+	SymbolicDataValueGenerator.RegisterGenerator rgen = new SymbolicDataValueGenerator.RegisterGenerator();
+	SymbolicDataValue.Register r1 = rgen.next(T_INT);
+	SymbolicDataValue.Register r2 = rgen.next(T_INT);
+	SymbolicDataValueGenerator.ParameterGenerator pgen = new SymbolicDataValueGenerator.ParameterGenerator();
+	SymbolicDataValue.Parameter p1 = pgen.next(T_INT);
 
-		RALocation l_eps = ra.addInitialState(false);
-		RALocation l_a = ra.addState(false);
-		RALocation l_aa = ra.addState(false);
-		RALocation l_aab = ra.addState(false);
-		RALocation l_aabb = ra.addState(false);
-		RALocation l_aabbb = ra.addState(false);
+	TransitionGuard trueGuard = new TransitionGuard();
+	TransitionGuard equalR1 =
+	    new TransitionGuard(new AtomicGuardExpression(r1, Relation.EQUALS, p1));
+	TransitionGuard notEqualR1 =
+	    new TransitionGuard(new AtomicGuardExpression(r1, Relation.NOT_EQUALS, p1));
 
-		RALocation l_sink = ra.addState(false);
-		RALocation l_final = ra.addState(true);
+	TransitionGuard disjunctionGuard =
+	    new TransitionGuard(new Disjunction(new AtomicGuardExpression(r1, Relation.EQUALS, p1),
+						new AtomicGuardExpression(r2, Relation.EQUALS, p1)));
 
-		SymbolicDataValueGenerator.RegisterGenerator rgen = new SymbolicDataValueGenerator.RegisterGenerator();
-		SymbolicDataValue.Register r1 = rgen.next(T_INT);
-		SymbolicDataValue.Register r2 = rgen.next(T_INT);
-		SymbolicDataValueGenerator.ParameterGenerator pgen = new SymbolicDataValueGenerator.ParameterGenerator();
-		SymbolicDataValue.Parameter p1 = pgen.next(T_INT);
-
-		TransitionGuard trueGuard = new TransitionGuard();
-		TransitionGuard equalR1 = new TransitionGuard(new AtomicGuardExpression(r1, Relation.EQUALS, p1));
-		TransitionGuard notEqualR1 = new TransitionGuard(new AtomicGuardExpression(r1, Relation.NOT_EQUALS, p1));
-
-		TransitionGuard disjunctionGuard = new TransitionGuard(new Disjunction(
-				new AtomicGuardExpression(r1, Relation.EQUALS, p1),
-				new AtomicGuardExpression(r2, Relation.EQUALS, p1)));
-
-		TransitionGuard elseGuard = new TransitionGuard(new Conjunction(
-				new AtomicGuardExpression(r1, Relation.NOT_EQUALS, p1),
-				new AtomicGuardExpression(r2, Relation.NOT_EQUALS, p1)));
+	TransitionGuard elseGuard =
+	    new TransitionGuard(new Conjunction(new AtomicGuardExpression(r1, Relation.NOT_EQUALS, p1),
+						new AtomicGuardExpression(r2, Relation.NOT_EQUALS, p1)));
 
 
-		VarMapping<SymbolicDataValue.Register, SymbolicDataValue> storeR1Mapping = new VarMapping<SymbolicDataValue.Register, SymbolicDataValue>();
-		storeR1Mapping.put(r1, p1);
-		VarMapping<SymbolicDataValue.Register, SymbolicDataValue> storeR1R2Mapping = new VarMapping<SymbolicDataValue.Register, SymbolicDataValue>();
-		storeR1R2Mapping.put(r1, p1);
-		storeR1R2Mapping.put(r2, r1);
-		VarMapping<SymbolicDataValue.Register, SymbolicDataValue> copyMapping = new VarMapping<SymbolicDataValue.Register, SymbolicDataValue>();
-		copyMapping.put(r1, r1);
-		copyMapping.put(r2, r2);
+	VarMapping<SymbolicDataValue.Register, SymbolicDataValue> storeR1Mapping = new VarMapping<SymbolicDataValue.Register, SymbolicDataValue>();
+	storeR1Mapping.put(r1, p1);
+	VarMapping<SymbolicDataValue.Register, SymbolicDataValue> storeR1R2Mapping = new VarMapping<SymbolicDataValue.Register, SymbolicDataValue>();
+	storeR1R2Mapping.put(r1, p1);
+	storeR1R2Mapping.put(r2, r1);
+	VarMapping<SymbolicDataValue.Register, SymbolicDataValue> copyMapping = new VarMapping<SymbolicDataValue.Register, SymbolicDataValue>();
+	copyMapping.put(r1, r1);
+	copyMapping.put(r2, r2);
 
-		VarMapping<SymbolicDataValue.Register, SymbolicDataValue> forgetMapping = new VarMapping<SymbolicDataValue.Register, SymbolicDataValue>();
-		forgetMapping.put(r1, r2);
+	VarMapping<SymbolicDataValue.Register, SymbolicDataValue> forgetMapping = new VarMapping<SymbolicDataValue.Register, SymbolicDataValue>();
+	forgetMapping.put(r1, r2);
 
-		VarMapping<Register, SymbolicDataValue> noMapping = new VarMapping<SymbolicDataValue.Register, SymbolicDataValue>();
+	VarMapping<Register, SymbolicDataValue> noMapping = new VarMapping<SymbolicDataValue.Register, SymbolicDataValue>();
 
-		Assignment storeR1 = new Assignment(storeR1Mapping);
-		Assignment storeR1R2 = new Assignment(storeR1R2Mapping);
-		Assignment copy = new Assignment(copyMapping);
-		Assignment forget = new Assignment(forgetMapping);
-		Assignment noAssign = new Assignment(noMapping);
+	Assignment storeR1 = new Assignment(storeR1Mapping);
+	Assignment storeR1R2 = new Assignment(storeR1R2Mapping);
+	Assignment copy = new Assignment(copyMapping);
+	Assignment forget = new Assignment(forgetMapping);
+	Assignment noAssign = new Assignment(noMapping);
 
-		ra.addTransition(l_eps, A, new InputTransition(trueGuard, A, l_eps, l_a, storeR1));
-		ra.addTransition(l_eps, B, new InputTransition(trueGuard, B, l_eps, l_sink, noAssign));
+	ra.addTransition(l_eps, A, new InputTransition(trueGuard, A, l_eps, l_a, storeR1));
+	ra.addTransition(l_eps, B, new InputTransition(trueGuard, B, l_eps, l_sink, noAssign));
 
-		ra.addTransition(l_a, A, new InputTransition(trueGuard, A, l_a, l_aa, storeR1R2));
-		ra.addTransition(l_a, B, new InputTransition(trueGuard, B, l_eps, l_sink, noAssign));
+	ra.addTransition(l_a, A, new InputTransition(trueGuard, A, l_a, l_aa, storeR1R2));
+	ra.addTransition(l_a, B, new InputTransition(trueGuard, B, l_eps, l_sink, noAssign));
 
-		ra.addTransition(l_aa, A, new InputTransition(elseGuard, A, l_aa, l_sink, noAssign));
-		ra.addTransition(l_aa, A, new InputTransition(disjunctionGuard, A, l_aa, l_final, noAssign));
-		ra.addTransition(l_aa, B, new InputTransition(trueGuard, B, l_aa, l_aab, copy));
+	ra.addTransition(l_aa, A, new InputTransition(elseGuard, A, l_aa, l_sink, noAssign));
+	ra.addTransition(l_aa, A, new InputTransition(disjunctionGuard, A, l_aa, l_final, noAssign));
+	ra.addTransition(l_aa, B, new InputTransition(trueGuard, B, l_aa, l_aab, copy));
 
-		ra.addTransition(l_aab, A, new InputTransition(trueGuard, A, l_aab, l_sink, noAssign));
-		ra.addTransition(l_aab, B, new InputTransition(trueGuard, B, l_aab, l_aabb, copy));
+	ra.addTransition(l_aab, A, new InputTransition(trueGuard, A, l_aab, l_sink, noAssign));
+	ra.addTransition(l_aab, B, new InputTransition(trueGuard, B, l_aab, l_aabb, copy));
 
-		ra.addTransition(l_aabb, A, new InputTransition(trueGuard, A, l_aabb, l_sink, noAssign));
-		ra.addTransition(l_aabb, B, new InputTransition(notEqualR1, B, l_aabb, l_sink, noAssign));
-		ra.addTransition(l_aabb, B, new InputTransition(equalR1, B, l_aabb, l_aabbb, forget));
+	ra.addTransition(l_aabb, A, new InputTransition(trueGuard, A, l_aabb, l_sink, noAssign));
+	ra.addTransition(l_aabb, B, new InputTransition(notEqualR1, B, l_aabb, l_sink, noAssign));
+	ra.addTransition(l_aabb, B, new InputTransition(equalR1, B, l_aabb, l_aabbb, forget));
 
-		ra.addTransition(l_aabbb, A, new InputTransition(trueGuard, A, l_aabbb, l_sink, noAssign));
-		ra.addTransition(l_aabbb, B, new InputTransition(notEqualR1, B, l_aabbb, l_sink, noAssign));
-		ra.addTransition(l_aabbb, B, new InputTransition(equalR1, B, l_aabbb, l_final, noAssign));
+	ra.addTransition(l_aabbb, A, new InputTransition(trueGuard, A, l_aabbb, l_sink, noAssign));
+	ra.addTransition(l_aabbb, B, new InputTransition(notEqualR1, B, l_aabbb, l_sink, noAssign));
+	ra.addTransition(l_aabbb, B, new InputTransition(equalR1, B, l_aabbb, l_final, noAssign));
 
-		ra.addTransition(l_final, A, new InputTransition(trueGuard, A, l_final, l_final, noAssign));
-		ra.addTransition(l_final, B, new InputTransition(trueGuard, B, l_final, l_final, noAssign));
-		ra.addTransition(l_sink, A, new InputTransition(trueGuard, A, l_sink, l_sink, noAssign));
-		ra.addTransition(l_sink, B, new InputTransition(trueGuard, B, l_sink, l_sink, noAssign));
+	ra.addTransition(l_final, A, new InputTransition(trueGuard, A, l_final, l_final, noAssign));
+	ra.addTransition(l_final, B, new InputTransition(trueGuard, B, l_final, l_final, noAssign));
+	ra.addTransition(l_sink, A, new InputTransition(trueGuard, A, l_sink, l_sink, noAssign));
+	ra.addTransition(l_sink, B, new InputTransition(trueGuard, B, l_sink, l_sink, noAssign));
 
-		return ra;
-	}
+	return ra;
+    }
 
-	@Test
-	public void learnSymmetryExampleCT() {
+    @Test
+    public void learnSymmetryExampleCT() {
+	Constants consts = new Constants();
+	RegisterAutomaton sul = buildCT();
+	DataWordOracle dwOracle = new SimulatorOracle(sul);
 
-		Constants consts = new Constants();
-		RegisterAutomaton sul = buildCT();
-	    DataWordOracle dwOracle = new SimulatorOracle(sul);
+	final Map<DataType, Theory> teachers = new LinkedHashMap<>();
+	teachers.put(T_INT, new IntegerEqualityTheory(T_INT));
 
-	    final Map<DataType, Theory> teachers = new LinkedHashMap<>();
-	    teachers.put(T_INT, new IntegerEqualityTheory(T_INT));
+	ConstraintSolver solver = new SimpleConstraintSolver();
 
-	    ConstraintSolver solver = new SimpleConstraintSolver();
-
-	    MultiTheoryTreeOracle mto = new MultiTheoryTreeOracle(dwOracle, teachers, new Constants(), solver);
+	MultiTheoryTreeOracle mto = new MultiTheoryTreeOracle(dwOracle, teachers, new Constants(), solver);
 
         SDTLogicOracle slo = new MultiTheorySDTLogicOracle(consts, solver);
 
         TreeOracleFactory hypFactory = (RegisterAutomaton hyp) ->
-                new MultiTheoryTreeOracle(new SimulatorOracle(hyp), teachers,
-                        new Constants(), solver);
+	    new MultiTheoryTreeOracle(new SimulatorOracle(hyp), teachers,
+				      new Constants(), solver);
 
         RaLambda learner = new RaLambda(mto, hypFactory, slo, consts, false, false, A, B);
         learner.setSolver(solver);
@@ -224,7 +219,7 @@ public class TestSymmetry extends RaLibTestSuite {
         learner.learn();
 
         Hypothesis hyp = learner.getHypothesis();
-        System.out.println(learner.getHypothesis().toString());
+        // System.out.println(learner.getHypothesis().toString());
 
         ce = Word.fromSymbols(
         		new PSymbolInstance(A, new DataValue(T_INT, 1)),
@@ -233,38 +228,38 @@ public class TestSymmetry extends RaLibTestSuite {
         		new PSymbolInstance(B, new DataValue(T_INT, 2)));
 
         Assert.assertTrue(hyp.accepts(ce));
-	}
+    }
 
-	private RegisterAutomaton buildCT() {
-		MutableRegisterAutomaton ra = new MutableRegisterAutomaton();
+    private RegisterAutomaton buildCT() {
+	MutableRegisterAutomaton ra = new MutableRegisterAutomaton();
 
-		RALocation l0 = ra.addInitialState(false);
-		RALocation l1 = ra.addState(false);
-		RALocation l2 = ra.addState(false);
-		RALocation l3 = ra.addState(true);
-		RALocation l4 = ra.addState(false);
+	RALocation l0 = ra.addInitialState(false);
+	RALocation l1 = ra.addState(false);
+	RALocation l2 = ra.addState(false);
+	RALocation l3 = ra.addState(true);
+	RALocation l4 = ra.addState(false);
 
-		SymbolicDataValueGenerator.RegisterGenerator rgen = new SymbolicDataValueGenerator.RegisterGenerator();
-		SymbolicDataValue.Register r1 = rgen.next(T_INT);
-		SymbolicDataValue.Register r2 = rgen.next(T_INT);
-		SymbolicDataValueGenerator.ParameterGenerator pgen = new SymbolicDataValueGenerator.ParameterGenerator();
-		SymbolicDataValue.Parameter p1 = pgen.next(T_INT);
+	SymbolicDataValueGenerator.RegisterGenerator rgen = new SymbolicDataValueGenerator.RegisterGenerator();
+	SymbolicDataValue.Register r1 = rgen.next(T_INT);
+	SymbolicDataValue.Register r2 = rgen.next(T_INT);
+	SymbolicDataValueGenerator.ParameterGenerator pgen = new SymbolicDataValueGenerator.ParameterGenerator();
+	SymbolicDataValue.Parameter p1 = pgen.next(T_INT);
 
-		TransitionGuard trueGuard = new TransitionGuard();
+	TransitionGuard trueGuard = new TransitionGuard();
         TransitionGuard equalR1 = new TransitionGuard(new AtomicGuardExpression(r1, Relation.EQUALS, p1));
         TransitionGuard notEqualR1 = new TransitionGuard(new AtomicGuardExpression(r1, Relation.NOT_EQUALS, p1));
         TransitionGuard disjunctionGuard = new TransitionGuard(new Disjunction(
         				new AtomicGuardExpression(r1, Relation.EQUALS, p1),
         				new AtomicGuardExpression(r2, Relation.EQUALS, p1)));
 
-		VarMapping<SymbolicDataValue.Register, SymbolicDataValue> storeR1Mapping = new VarMapping<SymbolicDataValue.Register, SymbolicDataValue>();
+	VarMapping<SymbolicDataValue.Register, SymbolicDataValue> storeR1Mapping = new VarMapping<SymbolicDataValue.Register, SymbolicDataValue>();
         storeR1Mapping.put(r1, p1);
-		VarMapping<SymbolicDataValue.Register, SymbolicDataValue> storeR2Mapping = new VarMapping<SymbolicDataValue.Register, SymbolicDataValue>();
+	VarMapping<SymbolicDataValue.Register, SymbolicDataValue> storeR2Mapping = new VarMapping<SymbolicDataValue.Register, SymbolicDataValue>();
         storeR2Mapping.put(r2, p1);
-		VarMapping<SymbolicDataValue.Register, SymbolicDataValue> storeR1R2Mapping = new VarMapping<SymbolicDataValue.Register, SymbolicDataValue>();
-		storeR1R2Mapping.put(r2, r1);
+	VarMapping<SymbolicDataValue.Register, SymbolicDataValue> storeR1R2Mapping = new VarMapping<SymbolicDataValue.Register, SymbolicDataValue>();
+	storeR1R2Mapping.put(r2, r1);
         storeR1R2Mapping.put(r1, p1);
-		VarMapping<SymbolicDataValue.Register, SymbolicDataValue> copyMapping = new VarMapping<SymbolicDataValue.Register, SymbolicDataValue>();
+	VarMapping<SymbolicDataValue.Register, SymbolicDataValue> copyMapping = new VarMapping<SymbolicDataValue.Register, SymbolicDataValue>();
         copyMapping.put(r1, r2);
         VarMapping<Register, SymbolicDataValue> noMapping = new VarMapping<SymbolicDataValue.Register, SymbolicDataValue>();
 
@@ -287,5 +282,5 @@ public class TestSymmetry extends RaLibTestSuite {
         ra.addTransition(l4, B, new InputTransition(trueGuard, B, l4, l4, noAssign));
 
         return ra;
-	}
+    }
 }

--- a/src/test/java/de/learnlib/ralib/tools/ClassAnalyzerTest.java
+++ b/src/test/java/de/learnlib/ralib/tools/ClassAnalyzerTest.java
@@ -28,7 +28,7 @@ import de.learnlib.ralib.RaLibTestSuite;
 public class ClassAnalyzerTest extends RaLibTestSuite {
 
     @Test
-    public void testClassAnalyzerWithMultilogin() {
+    public void classAnalyzerWithMultiloginTest() {
 
         final String[] options = new String[] {
             "class-analyzer",
@@ -53,13 +53,12 @@ public class ClassAnalyzerTest extends RaLibTestSuite {
             "rwalk.reset.count=false;" +
             "rwalk.draw.uniform=false;" +
             "teachers=uid:de.learnlib.ralib.tools.theories.IntegerEqualityTheory+" +
-             "pwd:de.learnlib.ralib.tools.theories.IntegerEqualityTheory;"};
+	    "pwd:de.learnlib.ralib.tools.theories.IntegerEqualityTheory;"};
 
         try {
             ConsoleClient cl = new ConsoleClient(options);
             int ret = cl.run();
             Assert.assertEquals(ret, 0);
-
         } catch (Throwable t) {
             t.printStackTrace();
             Assert.fail(t.getClass().getName());
@@ -67,8 +66,7 @@ public class ClassAnalyzerTest extends RaLibTestSuite {
     }
 
     @Test
-    public void testClassAnalyzerWithFreshValues() {
-
+    public void classAnalyzerWithFreshValuesTest() {
 
         final String[] options = new String[] {
             "class-analyzer",
@@ -95,15 +93,13 @@ public class ClassAnalyzerTest extends RaLibTestSuite {
             ConsoleClient cl = new ConsoleClient(options);
             int ret = cl.run();
             Assert.assertEquals(ret, 0);
-
         } catch (Throwable t) {
-
             Assert.fail(t.getClass().getName());
         }
     }
 
     @Test
-    public void testClassAnalyzerInequalities() {
+    public void classAnalyzerInequalitiesTest() {
 
         final String[] options = new String[] {
             "class-analyzer",
@@ -131,10 +127,8 @@ public class ClassAnalyzerTest extends RaLibTestSuite {
             int ret = cl.run();
             Assert.assertEquals(ret, 0);
         } catch (Throwable t) {
-
             Assert.fail(t.getClass().getName());
         }
-
     }
 
 }


### PR DESCRIPTION
Various tests in the test suite were just printing out the expected results rather than checking assertions with expected outcomes, which meant that regressions could escape attention. In addition, the test suite run was quite verbose.

This PR clean up most of the tests by adding appropriate assertions and comments out calls to printing functions. While at it, enforced a more homogeneous naming of tests and style of writing the code.