### PR TITLE
Remove left-over mentions of piv

### DIFF
--- a/src/main/java/de/learnlib/ralib/automata/output/OutputMapping.java
+++ b/src/main/java/de/learnlib/ralib/automata/output/OutputMapping.java
@@ -39,12 +39,12 @@ public class OutputMapping  {
 
     private final Collection<Parameter> fresh;
 
-    private final VarMapping<Parameter, SymbolicDataValue> piv;
+    private final VarMapping<Parameter, SymbolicDataValue> pmap;
 
     public OutputMapping(Collection<Parameter> fresh,
-            VarMapping<Parameter, SymbolicDataValue> piv) {
+            VarMapping<Parameter, SymbolicDataValue> pmap) {
         this.fresh = fresh;
-        this.piv = piv;
+        this.pmap = pmap;
     }
 
     public OutputMapping() {
@@ -68,12 +68,12 @@ public class OutputMapping  {
     }
 
     public VarMapping<Parameter, SymbolicDataValue> getOutput() {
-        return piv;
+        return pmap;
     }
 
     @Override
     public String toString() {
-        return "F:" + Arrays.toString(fresh.toArray()) + ", M:" + piv.toString();
+        return "F:" + Arrays.toString(fresh.toArray()) + ", M:" + pmap.toString();
     }
 
 }

--- a/src/main/java/de/learnlib/ralib/ceanalysis/PrefixFinder.java
+++ b/src/main/java/de/learnlib/ralib/ceanalysis/PrefixFinder.java
@@ -110,7 +110,7 @@ public class PrefixFinder {
 					LOGGER.trace(Category.DATASTRUCTURE, "idx: {} u': {}", idx, uPrime);
 					LOGGER.trace(Category.DATASTRUCTURE, "idx: {} v:  {}", idx, symSuffix);
 
-					// different piv sizes
+					// different sizes
 					//
 					if (!Memorables.typedSize(uPrimeResult.getDataValues()).equals(
 							Memorables.typedSize(uAlphaResult.getDataValues()))) {
@@ -250,7 +250,6 @@ public class PrefixFinder {
 
         	ParameterValuation pars = ParameterValuation.fromPSymbolWord(path);
         	Mapping<SymbolicDataValue, DataValue> vals = new Mapping<>();
-        	//vals.putAll(DataWords.computeRegisterValuation(pars, pivSul));
         	vals.putAll(pars);
         	vals.putAll(consts);
 

--- a/src/main/java/de/learnlib/ralib/dt/DTLeaf.java
+++ b/src/main/java/de/learnlib/ralib/dt/DTLeaf.java
@@ -521,8 +521,8 @@ public class DTLeaf extends DTNode implements LocationComponent {
         if (!paramsIntersect.isEmpty() && paramsIntersect.size() < memPrefix.size()) {
         	// word shares some data values with prefix, but not all
         	for (Map.Entry<SymbolicSuffix, SDT> e : mp.getTQRs().entrySet()) {
-        		Set<DataValue> piv = Set.of(e.getValue().getDataValues().toArray(new DataValue[0]));
-        		if (!Sets.intersection(piv, paramsIntersect).isEmpty()) {
+        		Set<DataValue> pmap = Set.of(e.getValue().getDataValues().toArray(new DataValue[0]));
+        		if (!Sets.intersection(pmap, paramsIntersect).isEmpty()) {
         			SDT sdt = e.getValue();
         			SymbolicSuffix newSuffix = suffixBuilder != null ?
         					suffixBuilder.extendSuffix(mp.getPrefix(), sdt, e.getKey()) :

--- a/src/main/java/de/learnlib/ralib/dt/PrefixSet.java
+++ b/src/main/java/de/learnlib/ralib/dt/PrefixSet.java
@@ -26,8 +26,8 @@ public class PrefixSet {
 		prefixes.add(p);
 	}
 
-	public void add(Word<PSymbolInstance> p, Bijection<DataValue> piv) {
-		prefixes.add(new MappedPrefix(p, piv));
+	public void add(Word<PSymbolInstance> p, Bijection<DataValue> pmap) {
+		prefixes.add(new MappedPrefix(p, pmap));
 	}
 
 	public boolean remove(MappedPrefix p) {

--- a/src/main/java/de/learnlib/ralib/learning/CounterexampleAnalysis.java
+++ b/src/main/java/de/learnlib/ralib/learning/CounterexampleAnalysis.java
@@ -122,12 +122,11 @@ public class CounterexampleAnalysis {
             return IndexResult.NO_CE;
         }
 
-        Set<DataValue> pivSul = resSul.getDataValues();
-        Set<DataValue> pivHyp = c.getPrimePrefix().getAssignment().keySet();
+        Set<DataValue> pSul = resSul.getDataValues();
+        Set<DataValue> pHyp = c.getPrimePrefix().getAssignment().keySet();
 
-        boolean sulHasMoreRegs = !pivHyp.containsAll(pivSul);
-        boolean hypRefinesTransition =
-                hypRefinesTransitions(location, act, resSul);
+        boolean sulHasMoreRegs = !pHyp.containsAll(pSul);
+        boolean hypRefinesTransition = hypRefinesTransitions(location, act, resSul);
 
 //        System.out.println("sulHasMoreRegs: " + sulHasMoreRegs);
 //        System.out.println("hypRefinesTransition: " + hypRefinesTransition);

--- a/src/main/java/de/learnlib/ralib/oracles/SDTLogicOracle.java
+++ b/src/main/java/de/learnlib/ralib/oracles/SDTLogicOracle.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014-2015 The LearnLib Contributors
+ * Copyright (C) 2014-2025 The LearnLib Contributors
  * This file is part of LearnLib, http://www.learnlib.de/.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -15,7 +15,6 @@
  * limitations under the License.
  */
 package de.learnlib.ralib.oracles;
-
 
 import de.learnlib.ralib.data.*;
 import de.learnlib.ralib.theory.SDT;
@@ -35,8 +34,7 @@ public interface SDTLogicOracle {
      * checks if there is a counterexample (a word that is accepted by one sdt
      * and rejected by the other sdt).
      *
-     * sdts are both after prefix. the piv objects describe respective assignments
-     * of registers of the sdts.
+     * sdts are both after prefix.
      *
      * rep is the dataword that was used for one transition in a hypothesis
      * with guard. Guard should be used to constrain the initial parameter values

--- a/src/main/java/de/learnlib/ralib/oracles/mto/MultiTheorySDTLogicOracle.java
+++ b/src/main/java/de/learnlib/ralib/oracles/mto/MultiTheorySDTLogicOracle.java
@@ -59,8 +59,6 @@ public class MultiTheorySDTLogicOracle implements SDTLogicOracle {
     public boolean hasCounterexample(Word<PSymbolInstance> prefix, SDT sdt1,
             SDT sdt2, Expression<Boolean> guard, Word<PSymbolInstance> rep) {
 
-        // Collection<SymbolicDataValue> join = piv1.values();
-
         LOGGER.trace("Searching for counterexample in SDTs");
         LOGGER.trace("SDT1: {0}", sdt1);
         LOGGER.trace("SDT2: {0}", sdt2);
@@ -80,7 +78,7 @@ public class MultiTheorySDTLogicOracle implements SDTLogicOracle {
         }
 
         exprG = SMTUtil.renameVars(exprG, gremap);
-        VarMapping<Register, Register> remap = new VarMapping<>(); //piv2.createRemapping(piv1);
+        VarMapping<Register, Register> remap = new VarMapping<>();
 
         Expression<Boolean> expr2r = SMTUtil.renameVars(expr2, remap);
         Expression<Boolean> left = ExpressionUtil.and(exprG, expr1, new Negation(expr2r));
@@ -111,20 +109,19 @@ public class MultiTheorySDTLogicOracle implements SDTLogicOracle {
 
     	for (Map.Entry<Expression<Boolean>, Boolean> e1 : exprMap1.entrySet()) {
             Expression<Boolean> expr1 = e1.getKey();
-    		boolean outcome1 = e1.getValue();
-    		for (Map.Entry<Expression<Boolean>, Boolean> e2 : exprMap2.entrySet()) {
+            boolean outcome1 = e1.getValue();
+            for (Map.Entry<Expression<Boolean>, Boolean> e2 : exprMap2.entrySet()) {
                 Expression<Boolean> expr2 = e2.getKey();
-    			boolean outcome2 = e2.getValue();
-    			if (outcome1 != outcome2) {
-    				//VarMapping<Register, Register> remap = piv2.createRemapping(piv1);
+                boolean outcome2 = e2.getValue();
+                if (outcome1 != outcome2) {
                     Expression<Boolean> test = ExpressionUtil.and(expr1, expr2);
-    				if (solver.isSatisfiable(test, new Mapping<>())) {
-    					return expr1;
-    				}
-    			}
-    		}
-    	}
-    	return null;
+                    if (solver.isSatisfiable(test, new Mapping<>())) {
+                        return expr1;
+                    }
+                }
+            }
+        }
+        return null;
     }
 
     @Override
@@ -132,8 +129,6 @@ public class MultiTheorySDTLogicOracle implements SDTLogicOracle {
 
         LOGGER.trace("refining: {0}", refining);
         LOGGER.trace("refined: {0}", refined);
-
-        //VarMapping<Register, Register> remap = pivRefined.createRemapping(pivRefining);
 
         Expression<Boolean> exprRefining = refining;
         Expression<Boolean> exprRefined = refined; //SMTUtil.renameVars(refined, remap);
@@ -178,8 +173,6 @@ public class MultiTheorySDTLogicOracle implements SDTLogicOracle {
         LOGGER.trace("guard2: {0}", guard2);
         LOGGER.trace("remapping: {0}", remapping);
 
-        //Mapping<DataValue, DataValue> remap = piv2.createRemapping(piv1);
-
         Expression<Boolean> g2relabel = SMTUtil.renameVals(guard2, remapping);
 
         Expression<Boolean> test = ExpressionUtil.or(
@@ -202,11 +195,6 @@ public class MultiTheorySDTLogicOracle implements SDTLogicOracle {
             "The height of the tree is not consistent with the number of parameters in the word";
         Mapping<SymbolicDataValue, DataValue> valuation = new Mapping<>();
         valuation.putAll(consts);
-        /*DataValue[] vals = DataWords.valsOf(prefix);
-        for (Map.Entry<Parameter, Register> entry : piv.entrySet()) {
-             DataValue parVal = vals[entry.getKey().getId()-1];
-             valuation.put(entry.getValue(), parVal);
-        }*/
 
         boolean accepts = accepts(word, prefix, prefix.length(), _sdt, valuation);
         return accepts;

--- a/src/main/java/de/learnlib/ralib/oracles/mto/MultiTheoryTreeOracle.java
+++ b/src/main/java/de/learnlib/ralib/oracles/mto/MultiTheoryTreeOracle.java
@@ -370,9 +370,8 @@ public class MultiTheoryTreeOracle implements TreeOracle {
         return ref1;
     }
 
-    // produces a mapping from top level SDT guards to the next level SDTs. Since
-    // the same guard can appear
-    // in multiple SDTs, the guard maps to a list of SDTs
+    // Produces a mapping from top level SDT guards to the next level SDTs.
+    // Since the same guard can appear in multiple SDTs, the guard maps to a list of SDTs.
     private Map<SDTGuard, List<SDT>> getChildren(SDT[] sdts) {
         List<Map<SDTGuard, SDT>> sdtChildren = Stream.of(sdts).map(sdt -> sdt.getChildren())
                 .collect(Collectors.toList());
@@ -390,8 +389,6 @@ public class MultiTheoryTreeOracle implements TreeOracle {
     private Mapping<SymbolicDataValue, DataValue> buildValuation(SuffixValuation suffixValuation,
             Word<PSymbolInstance> prefix, Constants constants) {
         Mapping<SymbolicDataValue, DataValue> valuation = new Mapping<SymbolicDataValue, DataValue>();
-        //DataValue[] values = DataWords.valsOf(prefix);
-        //piv.forEach((param, reg) -> valuation.put(reg, values[param.getId() - 1]));
         valuation.putAll(suffixValuation);
         valuation.putAll(constants);
         return valuation;

--- a/src/main/java/de/learnlib/ralib/theory/Theory.java
+++ b/src/main/java/de/learnlib/ralib/theory/Theory.java
@@ -63,7 +63,7 @@ public interface Theory {
      * data values (sv -> dv)
      * @param oracle the tree oracle in control of this query
      *
-     * @return a symbolic decision tree and updated piv
+     * @return a symbolic decision tree
      */
     SDT treeQuery(
             Word<PSymbolInstance> prefix,

--- a/src/main/java/de/learnlib/ralib/theory/inequality/InequalityTheoryWithEq.java
+++ b/src/main/java/de/learnlib/ralib/theory/inequality/InequalityTheoryWithEq.java
@@ -496,8 +496,6 @@ public abstract class InequalityTheoryWithEq implements Theory {
             List<DataValue> prefixValues, Constants constants,
             SuffixValuation pval) {
         if (SDTGuardElement.isDataValue(r)) {
-//            LOGGER.trace("piv: " + piv + " " + r.toString() + " " + prefixValues);
-//            LOGGER.trace("p: " + p.toString());
             return (DataValue) r;
         } else if (SDTGuardElement.isSuffixValue(r)) {
             return pval.get( (SuffixValue) r);


### PR DESCRIPTION
PIVs were removed from the code base in #101, but a few occurrences of `piv` were still present in comments, commented out code, and in variable names.  This PR removes these.